### PR TITLE
fix(monitor): out of range panics

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -471,7 +471,21 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 
 			baseFee := ms.SelectedBlock.BaseFee()
 			if transactionList.SelectedRow != 0 {
-				ms.SelectedTransaction = ms.SelectedBlock.Transactions()[transactionList.SelectedRow-1]
+				transactions := ms.SelectedBlock.Transactions()
+				if transactions != nil && len(transactions) > 0 {
+					index := transactionList.SelectedRow - 1
+					if index >= 0 && index < len(transactions) {
+						ms.SelectedTransaction = transactions[index]
+					} else {
+						log.Error().
+							Int("row", transactionList.SelectedRow).
+							Msg("Selected row is out of range for transactions")
+					}
+				} else {
+					log.Error().
+						Int("block", int(ms.SelectedBlock.Number().Uint64())).
+						Msg("No transactions available in the selected block")
+				}
 				transactionInformationList.Rows = ui.GetSimpleTxFields(ms.SelectedTransaction, ms.ChainID, baseFee)
 			}
 			termui.Clear()

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -506,13 +506,13 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 					skeleton.TxInfo.Rows = ui.GetSimpleTxFields(tx, ms.ChainID, baseFee)
 				} else {
 					log.Error().
-							Int("row", transactionList.SelectedRow).
-							Msg("Selected row is out of range for transactions")
+						Int("row", transactionList.SelectedRow).
+						Msg("Selected row is out of range for transactions")
 				}
 			} else {
 				log.Debug().
-						Int("block", int(ms.SelectedBlock.Number().Uint64())).
-						Msg("No transactions available in the selected block")
+					Int("block", int(ms.SelectedBlock.Number().Uint64())).
+					Msg("No transactions available in the selected block")
 			}
 			skeleton.Receipts.Rows = ui.GetSimpleReceipt(ctx, rpc, ms.SelectedTransaction)
 

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -482,7 +482,7 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 							Msg("Selected row is out of range for transactions")
 					}
 				} else {
-					log.Error().
+					log.Debug().
 						Int("block", int(ms.SelectedBlock.Number().Uint64())).
 						Msg("No transactions available in the selected block")
 				}
@@ -510,7 +510,7 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 							Msg("Selected row is out of range for transactions")
 				}
 			} else {
-				log.Error().
+				log.Debug().
 						Int("block", int(ms.SelectedBlock.Number().Uint64())).
 						Msg("No transactions available in the selected block")
 			}

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -472,7 +472,7 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			baseFee := ms.SelectedBlock.BaseFee()
 			if transactionList.SelectedRow != 0 {
 				transactions := ms.SelectedBlock.Transactions()
-				if transactions != nil && len(transactions) > 0 {
+				if len(transactions) > 0 {
 					index := transactionList.SelectedRow - 1
 					if index >= 0 && index < len(transactions) {
 						ms.SelectedTransaction = transactions[index]
@@ -498,7 +498,22 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			return
 		} else if currentMode == monitorModeTransaction {
 			baseFee := ms.SelectedBlock.BaseFee()
-			skeleton.TxInfo.Rows = ui.GetSimpleTxFields(ms.SelectedBlock.Transactions()[transactionList.SelectedRow-1], ms.ChainID, baseFee)
+			transactions := ms.SelectedBlock.Transactions()
+			if len(transactions) > 0 {
+				index := transactionList.SelectedRow - 1
+				if index > 0 && index < len(transactions) {
+					tx := transactions[index]
+					skeleton.TxInfo.Rows = ui.GetSimpleTxFields(tx, ms.ChainID, baseFee)
+				} else {
+					log.Error().
+							Int("row", transactionList.SelectedRow).
+							Msg("Selected row is out of range for transactions")
+				}
+			} else {
+				log.Error().
+						Int("block", int(ms.SelectedBlock.Number().Uint64())).
+						Msg("No transactions available in the selected block")
+			}
 			skeleton.Receipts.Rows = ui.GetSimpleReceipt(ctx, rpc, ms.SelectedTransaction)
 
 			termui.Clear()


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

- Add checks to ensure the selected block has transactions before attempting to access them.
- Implement bounds checking for the selected transaction index.
- Log errors for out-of-range selections and empty transaction lists.

## Jira / Linear Tickets

![image](https://github.com/user-attachments/assets/25992a45-3257-446b-8d01-da68d748d050)


https://0xpolygon.slack.com/archives/C07AWFULS49/p1726607070863549?thread_ts=1726607034.825629&cid=C07AWFULS49

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

```bash
polycli monitor --rpc-url https://rpc.cardona.zkevm-rpc.com
```

+ tried to scroll and explore the different blocks and txs
