### PR TITLE
fix: break from infinite loop when txn receipt not retrieved

### DIFF
--- a/cmd/loadtest/output.go
+++ b/cmd/loadtest/output.go
@@ -97,6 +97,11 @@ func printBlockSummary(c *ethclient.Client, bs map[uint64]blockSummary, startNon
 	successfulTx, totalTx := getSuccessfulTransactionCount(bs)
 	meanBlocktime, medianBlocktime, minBlocktime, maxBlocktime, stddevBlocktime, varianceBlocktime := getTimestampBlockSummary(bs)
 
+	if len(bs[0].Receipts) == 0 {
+		log.Error().Msg("Transaction receipts could not be retrieved")
+		return
+	}
+
 	if summaryOutputMode == "text" {
 		p.Printf("Successful Tx: %v\tTotal Tx: %v\n", number.Decimal(successfulTx), number.Decimal(totalTx))
 		p.Printf("Total Mining Time: %s\n", totalMiningTime)

--- a/util/util.go
+++ b/util/util.go
@@ -165,7 +165,7 @@ func GetReceipts(ctx context.Context, rawBlocks []*json.RawMessage, c *ethrpc.Cl
 		err := c.BatchCallContext(ctx, blms[start:end])
 		if err != nil {
 			log.Error().Err(err).Str("randtx", txHashes[0]).Uint64("start", start).Uint64("end", end).Msg("RPC issue fetching receipts")
-			return nil, err
+			break
 		}
 		start = end
 		if last {
@@ -181,6 +181,10 @@ func GetReceipts(ctx context.Context, rawBlocks []*json.RawMessage, c *ethrpc.Cl
 			return nil, b.Error
 		}
 		receipts = append(receipts, b.Result.(*json.RawMessage))
+	}
+	if len(receipts) == 0 {
+		log.Error().Msg("No receipts have been fetched")
+		return nil, nil
 	}
 	log.Info().Int("hashes", len(txHashes)).Int("receipts", len(receipts)).Msg("Fetched tx receipts")
 	return receipts, nil


### PR DESCRIPTION
# Description
This PR replaces the `return` with a `break` to stop the infinite loop in the case where the txn receipts are not retrieved. It is a measure to stop the process, but the root cause - `BatchCallContext` not working for batches with many txns still needs to be further investigated.

# Testing
## Before
![before](https://github.com/user-attachments/assets/ab4eaf7b-1155-4503-99d8-ed715e803c57)

## After
![image](https://github.com/user-attachments/assets/d276bad4-a77d-4d99-9e3a-ce483da0d9ae)
