### PR TITLE
fix: change possibly misleading total rates per second information an…

### DIFF
--- a/cmd/loadtest/output.go
+++ b/cmd/loadtest/output.go
@@ -482,7 +482,7 @@ func lightSummary(lts []loadTestSample, startTime, endTime time.Time, rl *rate.L
 	log.Info().Float64("tps", tps).Msg("Successful Requests Per Second")
 	// Only output total rates per second if there are failed transactions and TPS != RPS
 	if tps != rps {
-		log.Info().Float64("rps", rps).Msg("Total Requests Per Second (both successful and unsuccessful transactions)")
+		log.Error().Float64("rps", rps).Msg("Total Requests Per Second (both successful and unsuccessful transactions)")
 	}
 	log.Info().
 		Float64("mean", meanLat).

--- a/cmd/loadtest/output.go
+++ b/cmd/loadtest/output.go
@@ -464,7 +464,8 @@ func lightSummary(lts []loadTestSample, startTime, endTime time.Time, rl *rate.L
 	}
 
 	testDuration := endTime.Sub(startTime)
-	tps := float64(len(loadTestResults)) / testDuration.Seconds()
+	rps := float64(len(loadTestResults)) / testDuration.Seconds()
+	tps := float64(len(loadTestResults)-int(numErrors)) / testDuration.Seconds()
 
 	var rlLimit float64
 	if rl != nil {
@@ -478,7 +479,11 @@ func lightSummary(lts []loadTestSample, startTime, endTime time.Time, rl *rate.L
 
 	log.Info().Time("startTime", startTime).Msg("Start time of loadtest (first transaction sent)")
 	log.Info().Time("endTime", endTime).Msg("End time of loadtest (final transaction mined)")
-	log.Info().Float64("tps", tps).Msg("Overall Requests Per Second")
+	log.Info().Float64("tps", tps).Msg("Successful Requests Per Second")
+	// Only output total rates per second if there are failed transactions and TPS != RPS
+	if tps != rps {
+		log.Info().Float64("rps", rps).Msg("Total Requests Per Second (both successful and unsuccessful transactions)")
+	}
 	log.Info().
 		Float64("mean", meanLat).
 		Float64("median", medianLat).


### PR DESCRIPTION
# Description

This PR changes the loadtest output to fix possibly misleading `tps` output to `rps` (rates per second) which includes all successful and unsuccessful transactions sent to the RPC. Only the successful transactions would be used to calculate the actual `tps`. 


# Testing

![rps-tps](https://github.com/user-attachments/assets/5c15d785-c156-45fd-8b12-21d8ea3b85cc)
