### PR TITLE
chore: sort `polycli loadtest` modes

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -233,22 +233,24 @@ func initFlags() {
 	ltp.BlobFeeCap = LoadtestCmd.Flags().Uint64("blob-fee-cap", 100000, "The blob fee cap, or the maximum blob fee per chunk, in Gwei.")
 
 	// Local flags.
-	ltp.Modes = LoadtestCmd.Flags().StringSliceP("mode", "m", []string{"t"}, `The testing mode to use. It can be multiple like: "t,c,d,f"
-t - sending transactions
-d - deploy contract
-c - call random contract functions
-f - call specific contract function
-p - call random precompiled contracts
-a - call a specific precompiled contract address
-s - store mode
-r - random modes
-2 - ERC20 transfers
-7 - ERC721 mints
-v3 - UniswapV3 swaps
-R - total recall
-rpc - call random rpc methods
-cc, contract-call - call a contract method
-inscription - sending inscription transactions`)
+	ltp.Modes = LoadtestCmd.Flags().StringSliceP("mode", "m", []string{"t"}, `The testing mode to use. It can be multiple like: "c,d,f,t"
+2, erc20 - Send ERC20 tokens
+7, erc721 - Mint ERC721 tokens
+b, blob - Send blob transactions
+c, call - Call random contract functions
+cc, contract-call - Make contract calls
+d, deploy - Deploy contracts
+f, function - Call random contract functions
+i, inscription - Send inscription transactions
+inc, increment - Increment a counter
+pr, random-precompile - Call random precompiled contracts
+px, specific-precompile - Call specific precompiled contracts
+r, random - Random modes (does not include the following modes: blob, call, inscription, recall, rpc, uniswapv3)
+R, recall - Replay or simulate transactions
+rpc - Call random rpc methods
+s, store - Store bytes in a dynamic byte array
+t, transaction - Send transactions
+v3, uniswapv3 - Perform UniswapV3 swaps`)
 	ltp.Function = LoadtestCmd.Flags().Uint64P("function", "f", 1, "A specific function to be called if running with --mode f or a specific precompiled contract when running with --mode a")
 	ltp.ByteCount = LoadtestCmd.Flags().Uint64P("byte-count", "b", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
 	ltp.LtAddress = LoadtestCmd.Flags().String("lt-address", "", "The address of a pre-deployed load test contract")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -48,87 +48,107 @@ type (
 )
 
 const (
-	// these constants are stringered. If you add a new constant it fill fail to compile until you regenerate the strings. There are two steps needed.
-	// 1. Install stringer with something like `go install golang.org/x/tools/cmd/stringer`
-	// 2. now that its installed (make sure your GOBIN is on the PATH) you can run `go generate github.com/maticnetwork/polygon-cli/cmd/loadtest`
-	loadTestModeTransaction loadTestMode = iota
-	loadTestModeDeploy
-	loadTestModeCall
-	loadTestModeFunction
-	loadTestModeInc
-	loadTestModeStore
-	loadTestModeERC20
+	// These constants are "stringered".
+	// If you add a new constant, it fill fail to compile until you regenerate the strings.
+	// There are two steps needed:
+	// 1. Install stringer: `go install golang.org/x/tools/cmd/stringer`.
+	// 2. Generate the string: `go generate github.com/maticnetwork/polygon-cli/cmd/loadtest`.
+	// You can also use `make gen-loadtest-modes`.
+	loadTestModeERC20 loadTestMode = iota
 	loadTestModeERC721
-	loadTestModePrecompiledContracts
-	loadTestModePrecompiledContract
-
-	// All the modes AFTER random mode will not be used when mode random is selected
+	loadTestModeBlob
+	loadTestModeCall
+	loadTestModeContractCall
+	loadTestModeDeploy
+	loadTestModeFunction
+	loadTestModeInscription
+	loadTestModeIncrement
+	loadTestModeRandomPrecompiledContract
+	loadTestModeSpecificPrecompiledContract
 	loadTestModeRandom
 	loadTestModeRecall
 	loadTestModeRPC
-	loadTestModeContractCall
-	loadTestModeInscription
+	loadTestModeStore
+	loadTestModeTransaction
 	loadTestModeUniswapV3
-	loadTestModeBlob
-
+	
 	codeQualitySeed       = "code code code code code code code code code code code quality"
 	codeQualityPrivateKey = "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa"
 )
 
 func characterToLoadTestMode(mode string) (loadTestMode, error) {
 	switch mode {
-	case "t", "transaction":
-		return loadTestModeTransaction, nil
-	case "d", "deploy":
-		return loadTestModeDeploy, nil
-	case "c", "call":
-		return loadTestModeCall, nil
-	case "f", "function":
-		return loadTestModeFunction, nil
-	case "i", "inc", "increment":
-		return loadTestModeInc, nil
-	case "r", "random":
-		return loadTestModeRandom, nil
-	case "s", "store":
-		return loadTestModeStore, nil
 	case "2", "erc20":
-		return loadTestModeERC20, nil
+    return loadTestModeERC20, nil
 	case "7", "erc721":
-		return loadTestModeERC721, nil
-	case "p", "precompile":
-		return loadTestModePrecompiledContract, nil
-	case "P", "precompiles":
-		return loadTestModePrecompiledContracts, nil
-	case "R", "recall":
-		return loadTestModeRecall, nil
-	case "v3", "uniswapv3":
-		return loadTestModeUniswapV3, nil
-	case "rpc":
-		return loadTestModeRPC, nil
+			return loadTestModeERC721, nil
+	case "b", "blob":
+			return loadTestModeBlob, nil
+	case "c", "call":
+			return loadTestModeCall, nil
 	case "cc", "contract-call":
-		return loadTestModeContractCall, nil
-	case "inscription":
+			return loadTestModeContractCall, nil
+	case "d", "deploy":
+			return loadTestModeDeploy, nil
+	case "f", "function":
+			return loadTestModeFunction, nil
+	case "i", "inscription":
 		return loadTestModeInscription, nil
-	case "blob":
-		return loadTestModeBlob, nil
+	case "inc", "increment":
+			return loadTestModeIncrement, nil
+	case "pr", "random-precompile":
+			return loadTestModeRandomPrecompiledContract, nil
+	case "px", "specific-precompile":
+			return loadTestModeSpecificPrecompiledContract, nil
+	case "r", "random":
+			return loadTestModeRandom, nil
+	case "R", "recall":
+			return loadTestModeRecall, nil
+	case "rpc":
+			return loadTestModeRPC, nil
+	case "s", "store":
+			return loadTestModeStore, nil
+	case "t", "transaction":
+			return loadTestModeTransaction, nil
+	case "v3", "uniswapv3":
+			return loadTestModeUniswapV3, nil
 	default:
 		return 0, fmt.Errorf("unrecognized load test mode: %s", mode)
 	}
 }
 
 func getRandomMode() loadTestMode {
-	maxMode := int(loadTestModeRandom)
-	return loadTestMode(randSrc.Intn(maxMode))
+	// Does not include the following modes: blob, call, inscription, recall, rpc, uniswapv3
+	modes := []loadTestMode{
+		loadTestModeERC20,
+		loadTestModeERC721,
+		// loadTestModeBlob,
+		// loadTestModeCall,
+		loadTestModeContractCall,
+		loadTestModeDeploy,
+		loadTestModeFunction,
+		// loadTestModeInscription,
+		loadTestModeIncrement,
+		loadTestModeRandomPrecompiledContract,
+		loadTestModeSpecificPrecompiledContract,
+		// loadTestModeRandom,
+		// loadTestModeRecall,
+		// loadTestModeRPC,
+		loadTestModeStore,
+		loadTestModeTransaction,
+		// loadTestModeUniswapV3,
+	}
+	return modes[randSrc.Intn(len(modes))]
 }
 
 func modeRequiresLoadTestContract(m loadTestMode) bool {
 	if m == loadTestModeCall ||
 		m == loadTestModeFunction ||
-		m == loadTestModeInc ||
+		m == loadTestModeIncrement ||
 		m == loadTestModeRandom ||
 		m == loadTestModeStore ||
-		m == loadTestModePrecompiledContract ||
-		m == loadTestModePrecompiledContracts {
+		m == loadTestModeRandomPrecompiledContract ||
+		m == loadTestModeSpecificPrecompiledContract {
 		return true
 	}
 	return false
@@ -651,37 +671,37 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 					localMode = getRandomMode()
 				}
 				switch localMode {
-				case loadTestModeTransaction:
-					startReq, endReq, tErr = loadTestTransaction(ctx, c, myNonceValue)
-				case loadTestModeDeploy:
-					startReq, endReq, tErr = loadTestDeploy(ctx, c, myNonceValue)
-				case loadTestModeFunction, loadTestModeCall:
-					startReq, endReq, tErr = loadTestFunction(ctx, c, myNonceValue, ltContract)
-				case loadTestModeInc:
-					startReq, endReq, tErr = loadTestInc(ctx, c, myNonceValue, ltContract)
-				case loadTestModeStore:
-					startReq, endReq, tErr = loadTestStore(ctx, c, myNonceValue, ltContract)
 				case loadTestModeERC20:
 					startReq, endReq, tErr = loadTestERC20(ctx, c, myNonceValue, erc20Contract, ltAddr)
 				case loadTestModeERC721:
 					startReq, endReq, tErr = loadTestERC721(ctx, c, myNonceValue, erc721Contract, ltAddr)
-				case loadTestModePrecompiledContract:
-					startReq, endReq, tErr = loadTestCallPrecompiledContracts(ctx, c, myNonceValue, ltContract, true)
-				case loadTestModePrecompiledContracts:
-					startReq, endReq, tErr = loadTestCallPrecompiledContracts(ctx, c, myNonceValue, ltContract, false)
+				case loadTestModeBlob:
+					startReq, endReq, tErr = loadTestBlob(ctx, c, myNonceValue)
+				case loadTestModeContractCall:
+					startReq, endReq, tErr = loadTestContractCall(ctx, c, myNonceValue)
+				case loadTestModeDeploy:
+					startReq, endReq, tErr = loadTestDeploy(ctx, c, myNonceValue)
+				case loadTestModeFunction, loadTestModeCall:
+					startReq, endReq, tErr = loadTestFunction(ctx, c, myNonceValue, ltContract)
+				case loadTestModeInscription:
+					startReq, endReq, tErr = loadTestInscription(ctx, c, myNonceValue)
+				case loadTestModeIncrement:
+					startReq, endReq, tErr = loadTestIncrement(ctx, c, myNonceValue, ltContract)
+				case loadTestModeRandomPrecompiledContract:
+					startReq, endReq, tErr = loadTestCallPrecompiledContract(ctx, c, myNonceValue, ltContract, true)
+				case loadTestModeSpecificPrecompiledContract:
+					startReq, endReq, tErr = loadTestCallPrecompiledContract(ctx, c, myNonceValue, ltContract, false)
 				case loadTestModeRecall:
 					startReq, endReq, tErr = loadTestRecall(ctx, c, myNonceValue, recallTransactions[int(currentNonce)%len(recallTransactions)])
+				case loadTestModeRPC:
+					startReq, endReq, tErr = loadTestRPC(ctx, c, myNonceValue, indexedActivity)
+				case loadTestModeStore:
+					startReq, endReq, tErr = loadTestStore(ctx, c, myNonceValue, ltContract)
+				case loadTestModeTransaction:
+					startReq, endReq, tErr = loadTestTransaction(ctx, c, myNonceValue)
 				case loadTestModeUniswapV3:
 					swapAmountIn := big.NewInt(int64(*uniswapv3LoadTestParams.SwapAmountInput))
 					startReq, endReq, tErr = runUniswapV3Loadtest(ctx, c, myNonceValue, uniswapV3Config, poolConfig, swapAmountIn)
-				case loadTestModeRPC:
-					startReq, endReq, tErr = loadTestRPC(ctx, c, myNonceValue, indexedActivity)
-				case loadTestModeContractCall:
-					startReq, endReq, tErr = loadTestContractCall(ctx, c, myNonceValue)
-				case loadTestModeInscription:
-					startReq, endReq, tErr = loadTestInscription(ctx, c, myNonceValue)
-				case loadTestModeBlob:
-					startReq, endReq, tErr = loadTestBlob(ctx, c, myNonceValue)
 				default:
 					log.Error().Str("mode", mode.String()).Msg("We've arrived at a load test mode that we don't recognize")
 				}
@@ -1008,7 +1028,7 @@ func loadTestFunction(ctx context.Context, c *ethclient.Client, nonce uint64, lt
 	return
 }
 
-func loadTestCallPrecompiledContracts(ctx context.Context, c *ethclient.Client, nonce uint64, ltContract *tester.LoadTester, useSelectedAddress bool) (t1 time.Time, t2 time.Time, err error) {
+func loadTestCallPrecompiledContract(ctx context.Context, c *ethclient.Client, nonce uint64, ltContract *tester.LoadTester, useSelectedAddress bool) (t1 time.Time, t2 time.Time, err error) {
 	var f int
 	ltp := inputLoadTestParams
 
@@ -1046,7 +1066,7 @@ func loadTestCallPrecompiledContracts(ctx context.Context, c *ethclient.Client, 
 	return
 }
 
-func loadTestInc(ctx context.Context, c *ethclient.Client, nonce uint64, ltContract *tester.LoadTester) (t1 time.Time, t2 time.Time, err error) {
+func loadTestIncrement(ctx context.Context, c *ethclient.Client, nonce uint64, ltContract *tester.LoadTester) (t1 time.Time, t2 time.Time, err error) {
 	ltp := inputLoadTestParams
 
 	chainID := new(big.Int).SetUint64(*ltp.ChainID)

--- a/cmd/loadtest/loadtestmode_string.go
+++ b/cmd/loadtest/loadtestmode_string.go
@@ -8,28 +8,28 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[loadTestModeTransaction-0]
-	_ = x[loadTestModeDeploy-1]
-	_ = x[loadTestModeCall-2]
-	_ = x[loadTestModeFunction-3]
-	_ = x[loadTestModeInc-4]
-	_ = x[loadTestModeStore-5]
-	_ = x[loadTestModeERC20-6]
-	_ = x[loadTestModeERC721-7]
-	_ = x[loadTestModePrecompiledContracts-8]
-	_ = x[loadTestModePrecompiledContract-9]
-	_ = x[loadTestModeRandom-10]
-	_ = x[loadTestModeRecall-11]
-	_ = x[loadTestModeRPC-12]
-	_ = x[loadTestModeContractCall-13]
-	_ = x[loadTestModeInscription-14]
-	_ = x[loadTestModeUniswapV3-15]
-	_ = x[loadTestModeBlob-16]
+	_ = x[loadTestModeERC20-0]
+	_ = x[loadTestModeERC721-1]
+	_ = x[loadTestModeBlob-2]
+	_ = x[loadTestModeCall-3]
+	_ = x[loadTestModeContractCall-4]
+	_ = x[loadTestModeDeploy-5]
+	_ = x[loadTestModeFunction-6]
+	_ = x[loadTestModeInscription-7]
+	_ = x[loadTestModeIncrement-8]
+	_ = x[loadTestModeRandomPrecompiledContract-9]
+	_ = x[loadTestModeSpecificPrecompiledContract-10]
+	_ = x[loadTestModeRandom-11]
+	_ = x[loadTestModeRecall-12]
+	_ = x[loadTestModeRPC-13]
+	_ = x[loadTestModeStore-14]
+	_ = x[loadTestModeTransaction-15]
+	_ = x[loadTestModeUniswapV3-16]
 }
 
-const _loadTestMode_name = "loadTestModeTransactionloadTestModeDeployloadTestModeCallloadTestModeFunctionloadTestModeIncloadTestModeStoreloadTestModeERC20loadTestModeERC721loadTestModePrecompiledContractsloadTestModePrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeContractCallloadTestModeInscriptionloadTestModeUniswapV3loadTestModeBlob"
+const _loadTestMode_name = "loadTestModeERC20loadTestModeERC721loadTestModeBlobloadTestModeCallloadTestModeContractCallloadTestModeDeployloadTestModeFunctionloadTestModeInscriptionloadTestModeIncrementloadTestModeRandomPrecompiledContractloadTestModeSpecificPrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeStoreloadTestModeTransactionloadTestModeUniswapV3"
 
-var _loadTestMode_index = [...]uint16{0, 23, 41, 57, 77, 92, 109, 126, 144, 176, 207, 225, 243, 258, 282, 305, 326, 342}
+var _loadTestMode_index = [...]uint16{0, 17, 35, 51, 67, 91, 109, 129, 152, 173, 210, 249, 267, 285, 300, 317, 340, 361}
 
 func (i loadTestMode) String() string {
 	if i < 0 || i >= loadTestMode(len(_loadTestMode_index)-1) {

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -128,22 +128,24 @@ The codebase has a contract that used for load testing. It's written in Solidity
   -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
       --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
       --lt-address string                      The address of a pre-deployed load test contract
-  -m, --mode strings                           The testing mode to use. It can be multiple like: "t,c,d,f"
-                                               t - sending transactions
-                                               d - deploy contract
-                                               c - call random contract functions
-                                               f - call specific contract function
-                                               p - call random precompiled contracts
-                                               a - call a specific precompiled contract address
-                                               s - store mode
-                                               r - random modes
-                                               2 - ERC20 transfers
-                                               7 - ERC721 mints
-                                               v3 - UniswapV3 swaps
-                                               R - total recall
-                                               rpc - call random rpc methods
-                                               cc, contract-call - call a contract method
-                                               inscription - sending inscription transactions (default [t])
+  -m, --mode strings                           The testing mode to use. It can be multiple like: "c,d,f,t"
+                                               2, erc20 - Send ERC20 tokens
+                                               7, erc721 - Mint ERC721 tokens
+                                               b, blob - Send blob transactions
+                                               c, call - Call random contract functions
+                                               cc, contract-call - Make contract calls
+                                               d, deploy - Deploy contracts
+                                               f, function - Call random contract functions
+                                               i, inscription - Send inscription transactions
+                                               inc, increment - Increment a counter
+                                               pr, random-precompile - Call random precompiled contracts
+                                               px, specific-precompile - Call specific precompiled contracts
+                                               r, random - Random modes (does not include the following modes: blob, call, inscription, recall, rpc, uniswapv3)
+                                               R, recall - Replay or simulate transactions
+                                               rpc - Call random rpc methods
+                                               s, store - Store bytes in a dynamic byte array
+                                               t, transaction - Send transactions
+                                               v3, uniswapv3 - Perform UniswapV3 swaps (default [t])
       --output-mode string                     Format mode for summary output (json | text) (default "text")
       --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
       --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Sort `polycli loadtest` modes.

Before:

```bash
-m, --mode strings                           The testing mode to use. It can be multiple like: "t,c,d,f"
                                               t - sending transactions
                                               d - deploy contract
                                               c - call random contract functions
                                               f - call specific contract function
                                               p - call random precompiled contracts
                                               a - call a specific precompiled contract address
                                               s - store mode
                                               r - random modes
                                               2 - ERC20 transfers
                                               7 - ERC721 mints
                                               v3 - UniswapV3 swaps
                                               R - total recall
                                               rpc - call random rpc methods
                                               cc, contract-call - call a contract method
                                               inscription - sending inscription transactions (default [t])

```

After:

```bash
-m, --mode strings                           The testing mode to use. It can be multiple like: "c,d,f,t"
                                               2, erc20 - Send ERC20 tokens
                                               7, erc721 - Mint ERC721 tokens
                                               b, blob - Send blob transactions
                                               c, call - Call random contract functions
                                               cc, contract-call - Make contract calls
                                               d, deploy - Deploy contracts
                                               f, function - Call random contract functions
                                               i, inscription - Send inscription transactions
                                               inc, increment - Increment a counter
                                               pr, random-precompile - Call random precompiled contracts
                                               px, specific-precompile - Call specific precompiled contracts
                                               r, random - Random modes (does not include the following modes: blob, call, inscription, rpc, recall, uniswapv3)
                                               R, recall - Replay or simulate transactions
                                               rpc - Call random rpc methods
                                               s, store - Store bytes in a dynamic byte array
                                               t, transaction - Send transactions
                                               v3, uniswapv3 - Perform UniswapV3 swaps (default [t])

```

## Jira / Linear Tickets

x

# Testing

x
