### PR TITLE
feat: silence usage when error returned for monitor

### DIFF
--- a/cmd/monitor/cmd.go
+++ b/cmd/monitor/cmd.go
@@ -51,10 +51,11 @@ func (s *SafeBatchSize) Auto() bool {
 }
 
 var MonitorCmd = &cobra.Command{
-	Use:   "monitor",
-	Short: "Monitor blocks using a JSON-RPC endpoint.",
-	Long:  usage,
-	Args:  cobra.NoArgs,
+	Use:          "monitor",
+	Short:        "Monitor blocks using a JSON-RPC endpoint.",
+	Long:         usage,
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// By default, hide logs from `polycli monitor`.
 		verbosityFlag := cmd.Flag("verbosity")

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -167,7 +167,7 @@ func monitor(ctx context.Context) error {
 			for {
 				err = fetchCurrentBlockData(ctx, ec, ms, isUiRendered)
 				if err != nil {
-					log.Error().Msg(fmt.Sprintf("Error: %v", err))
+					log.Error().Msg(fmt.Sprintf("Error: unable to fetch current block data: %v", err))
 					// Send the error to the errChan channel to return.
 					errChan <- err
 					return


### PR DESCRIPTION
# Description

This PR silences the usage output when an error is returned in `polycli monitor`

# Testing

## Before
The usage for `polycli monitor` is returned along with the error.
![img-before](https://github.com/user-attachments/assets/e5a3c6a2-24de-4a3d-b767-455a3bbd5d7e)

## After
Only the error is returned.
![image](https://github.com/user-attachments/assets/a1733fdb-6211-4685-86fe-e1d547d7ca7e)

