### PR TITLE
ci: bump go version from 1.21 to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.21"                  # https://go.dev/dl/
-  STRINGER_VERSION: "0.26.0"          # https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
+  GO_VERSION: "1.22" # https://go.dev/dl/
+  STRINGER_VERSION: "0.26.0" # https://pkg.go.dev/golang.org/x/tools/cmd/stringer?tab=versions
   # Protoc dependencies.
-  PROTOC_VERSION: "28.2"              # https://github.com/protocolbuffers/protobuf/releases
-  PROTOC_GEN_GO_VERSION: "1.35.1"     # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions
+  PROTOC_VERSION: "28.2" # https://github.com/protocolbuffers/protobuf/releases
+  PROTOC_GEN_GO_VERSION: "1.35.1" # https://pkg.go.dev/google.golang.org/protobuf/cmd/protoc-gen-go?tab=versions
   PROTOC_GEN_GO_GRPC_VERSION: "1.5.1" # https://pkg.go.dev/google.golang.org/grpc/cmd/protoc-gen-go-grpc?tab=versions
   ARCH: "linux-x86_64"
 
@@ -143,7 +143,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      
+
       - name: Install dependencies
         run: go get
       - name: Install polycli using go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 env:
-  GO_VERSION: "1.21"
+  GO_VERSION: "1.22"
 
 jobs:
   manual-release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS builder
+FROM golang:1.22 AS builder
 WORKDIR /workspace
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes and the related issue. Indicate
which changes are breaking. Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Follow up of https://github.com/0xPolygon/polygon-cli/pull/399

## Jira / Linear Tickets

x

# Testing

x
