### PR TITLE
add dns discovery to sensor logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ coverage.out
 *.swo
 
 wallets.json
-nodes.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage.out
 *.swo
 
 wallets.json
+nodes.json

--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -395,7 +395,7 @@ func handleDNSDiscovery(server *ethp2p.Server, peers map[enode.ID]string, peersM
 	}
 
 	log.Info().
-		Str("discover-dns", inputSensorParams.DiscoveryDNS).
+		Str("discovery-dns", inputSensorParams.DiscoveryDNS).
 		Msg("Starting DNS discovery sync")
 
 	client := dnsdisc.NewClient(dnsdisc.Config{})

--- a/doc/polycli_p2p_sensor.md
+++ b/doc/polycli_p2p_sensor.md
@@ -28,6 +28,7 @@ If no nodes.json file exists, it will be created.
   -d, --database-id string       Datastore database ID
       --dial-ratio int           Ratio of inbound to dialed connections. A dial ratio of 2 allows 1/2 of
                                  connections to be dialed. Setting this to 0 defaults it to 3.
+      --discovery-dns string     DNS discovery ENR tree url
       --discovery-port int       UDP P2P discovery port (default 30303)
       --fork-id bytesHex         The hex encoded fork id (omit the 0x) (default F097BC13)
       --genesis-hash string      The genesis block hash (default "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b")
@@ -37,7 +38,7 @@ If no nodes.json file exists, it will be created.
   -D, --max-db-concurrency int   Maximum number of concurrent database operations to perform. Increasing this
                                  will result in less chance of missing data (i.e. broken pipes) but can
                                  significantly increase memory usage. (default 10000)
-  -m, --max-peers int            Maximum number of peers to connect to (default 200)
+  -m, --max-peers int            Maximum number of peers to connect to (default 2000)
       --nat string               NAT port mapping mechanism (any|none|upnp|pmp|pmp:<IP>|extip:<IP>) (default "any")
   -n, --network-id uint          Filter discovered nodes by this network ID
       --port int                 TCP network listening port (default 30303)


### PR DESCRIPTION
# Description

new features:
- on start, force add all enodes from Polygon's dns discovery, dramatically increasing peer count to several hundred peers
- add hourly ticker to recurrently add new peers from DNS ENR tree 

# Testing

smoke tests locally working as expected and seeing several hundred peers via prometheus port:
`go run main.go p2p sensor nodes.json \
  --network-id 137 \
  --sensor-id mvu \
  --write-blocks=false \
  --write-block-events=false \
  --write-txs=false \
  --write-tx-events=false \
  --rpc "https://polygon-rpc.com" \
  --discovery-dns "enrtree://AKUEZKN7PSKVNR65FZDHECMKOJQSGPARGTPPBI7WS2VUL4EGR6XPC@pos.polygon-peers.io" \
  --verbosity 700 --quick-start --key "d8168fb642add845920b91291ec8bbf7c4d5dd2aeaed330fb9e75d766b957f53"`

<img width="728" alt="image" src="https://github.com/user-attachments/assets/1f44d586-0ebb-47d1-9d5e-62d9c1277f4b">

<img width="927" alt="image" src="https://github.com/user-attachments/assets/9270d313-5901-4936-88b7-31df7b0912c2">

