### PR TITLE
cost control: dedupe writeEvents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ coverage.out
 *.swo
 
 wallets.json
+
+*.key

--- a/p2p/database/datastore.go
+++ b/p2p/database/datastore.go
@@ -131,8 +131,8 @@ type DatastoreOptions struct {
 
 const (
 	shardCount      = 32
-	cleanupInterval = 10 * time.Minute // Interval between cleanups
-	entryTTL        = 1 * time.Hour    // TTL for each entry
+	cleanupInterval = 5 * time.Minute    // Interval between cleanups
+	entryTTL        = 20 * time.Minute   // TTL for each entry
 )
 
 var (

--- a/p2p/database/datastore.go
+++ b/p2p/database/datastore.go
@@ -191,6 +191,10 @@ func cleanupDedupMap() {
                 }
             }
             dedupMaps[i] = newShard // Replace with the new, trimmed map
+
+            // Log the size of the shard after cleanup for monitoring
+            log.Printf("Shard %d size after cleanup: %d entries", i, len(dedupMaps[i]))
+
             mu.Unlock()
         }
     }

--- a/p2p/database/datastore.go
+++ b/p2p/database/datastore.go
@@ -130,9 +130,9 @@ type DatastoreOptions struct {
 }
 
 const (
-	shardCount   = 32
-	cleanupInterval = 10 * time.Minute  // Interval between cleanups
-	entryTTL        = 1 * time.Hour      // TTL for each entry
+	shardCount      = 32
+	cleanupInterval = 10 * time.Minute // Interval between cleanups
+	entryTTL        = 1 * time.Hour    // TTL for each entry
 )
 
 var (


### PR DESCRIPTION
# Description

- deduplicate blockEvents by unique: sensorID, peerID, and hash combos
- add sharded mutex maps to prevent goRoutine contention
- add dedupe map cleanup periodically to prevent memory exhaustion

# Testing

smoke tests locally, no go errors on run
**unclear how to test event writing locally**
