### PR TITLE
feat: add forkid to monitor

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -238,7 +238,7 @@ func getChainState(ctx context.Context, ec *ethclient.Client) (*chainState, erro
 
 	cs.ForkID, err = util.GetForkID(ec.Client())
 	if err != nil {
-		return nil, fmt.Errorf("Unable to get fork id", err.Error())
+		log.Debug().Err(err).Msg("Unable to get fork id")
 	}
 
 	return cs, nil

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -10,19 +10,19 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/0xPolygon/polygon-cli/util"
+	lru "github.com/hashicorp/golang-lru"
 
 	_ "embed"
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 
-	"github.com/cenkalti/backoff/v4"
-	termui "github.com/gizak/termui/v3"
 	"github.com/0xPolygon/polygon-cli/cmd/monitor/ui"
 	"github.com/0xPolygon/polygon-cli/metrics"
 	"github.com/0xPolygon/polygon-cli/rpctypes"
+	"github.com/cenkalti/backoff/v4"
+	termui "github.com/gizak/termui/v3"
 	"github.com/rs/zerolog/log"
 )
 
@@ -62,6 +62,7 @@ type (
 		UpperBlock          *big.Int
 		LowerBlock          *big.Int
 		ChainID             *big.Int
+		ForkID              uint64
 		HeadBlock           *big.Int
 		PeerCount           uint64
 		GasPrice            *big.Int
@@ -79,6 +80,7 @@ type (
 		GasPrice     *big.Int
 		TxPoolStatus txPoolStatus
 		ZkEVMBatches zkEVMBatches
+		ForkID       uint64
 	}
 	txPoolStatus struct {
 		pending uint64
@@ -234,6 +236,11 @@ func getChainState(ctx context.Context, ec *ethclient.Client) (*chainState, erro
 		log.Debug().Err(err).Msg("Unable to get zkevm batches")
 	}
 
+	cs.ForkID, err = util.GetForkID(ec.Client())
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get fork id", err.Error())
+	}
+
 	return cs, nil
 
 }
@@ -276,6 +283,7 @@ func fetchCurrentBlockData(ctx context.Context, ec *ethclient.Client, ms *monito
 	ms.GasPrice = cs.GasPrice
 	ms.TxPoolStatus = cs.TxPoolStatus
 	ms.ZkEVMBatches = cs.ZkEVMBatches
+	ms.ForkID = cs.ForkID
 
 	return
 }
@@ -594,8 +602,11 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			skeleton.TxPool.Text = ui.GetTxPoolText(skeleton.TxPool, ms.TxPoolStatus.pending, ms.TxPoolStatus.queued)
 		}
 
+		// if zkEVMBatchesSupported == true, this means the network will also support ForkIDs.
 		if zkEVMBatchesSupported {
 			skeleton.ZkEVM.Text = ui.GetZkEVMText(skeleton.ZkEVM, ms.ZkEVMBatches.trusted, ms.ZkEVMBatches.virtual, ms.ZkEVMBatches.verified)
+
+			skeleton.Rollup.Text = ui.GetRollupText(skeleton.Rollup, ms.ForkID)
 		}
 
 		skeleton.TxPerBlockChart.Data = metrics.GetTxsPerBlock(renderedBlocks)

--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/0xPolygon/polygon-cli/metrics"
+	"github.com/0xPolygon/polygon-cli/rpctypes"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	ui "github.com/gizak/termui/v3"
 	"github.com/gizak/termui/v3/widgets"
-	"github.com/0xPolygon/polygon-cli/metrics"
-	"github.com/0xPolygon/polygon-cli/rpctypes"
 	"github.com/rs/zerolog/log"
 )
 
@@ -25,15 +25,15 @@ var (
 )
 
 type UiSkeleton struct {
-	Current, TxPool, ZkEVM *widgets.Paragraph
-	TxPerBlockChart        *widgets.Sparkline
-	GasPriceChart          *widgets.Sparkline
-	BlockSizeChart         *widgets.Sparkline
-	PendingTxChart         *widgets.Sparkline
-	GasChart               *widgets.Sparkline
-	BlockInfo              *widgets.List
-	TxInfo                 *widgets.List
-	Receipts               *widgets.List
+	Current, TxPool, ZkEVM, Rollup *widgets.Paragraph
+	TxPerBlockChart                *widgets.Sparkline
+	GasPriceChart                  *widgets.Sparkline
+	BlockSizeChart                 *widgets.Sparkline
+	PendingTxChart                 *widgets.Sparkline
+	GasChart                       *widgets.Sparkline
+	BlockInfo                      *widgets.List
+	TxInfo                         *widgets.List
+	Receipts                       *widgets.List
 }
 
 func GetCurrentText(widget *widgets.Paragraph, headBlock *big.Int, gasPrice string, peerCount uint64, chainID *big.Int, rpcURL string) string {
@@ -64,6 +64,11 @@ func GetZkEVMText(widget *widgets.Paragraph, trustedBatchesCount, virtualBatches
 	trustedVerifiedBatchesGap := trustedBatchesCount - verifiedBatchesCount
 	verifiedBatches := fmt.Sprintf("Verified: %d (%d)", verifiedBatchesCount, trustedVerifiedBatchesGap)
 	return formatParagraph(widget, []string{trustedBatches, virtualBatches, verifiedBatches})
+}
+
+func GetRollupText(widget *widgets.Paragraph, forkID uint64) string {
+	forkIDString := fmt.Sprintf("ForkID:  %d", forkID)
+	return formatParagraph(widget, []string{forkIDString})
 }
 
 func formatParagraph(widget *widgets.Paragraph, content []string) string {
@@ -524,6 +529,10 @@ func SetUISkeleton(txPoolStatusSupported, zkEVMBatchesSupported bool) (blockList
 		termUi.ZkEVM = widgets.NewParagraph()
 		termUi.ZkEVM.Title = "ZkEVM Batch No."
 		totalWidgets++
+
+		termUi.Rollup = widgets.NewParagraph()
+		termUi.Rollup.Title = "Rollup Info"
+		totalWidgets++
 	}
 
 	topRowBlocks := []interface{}{
@@ -534,6 +543,8 @@ func SetUISkeleton(txPoolStatusSupported, zkEVMBatchesSupported bool) (blockList
 	}
 	if zkEVMBatchesSupported {
 		topRowBlocks = append(topRowBlocks, ui.NewCol(1.0/5.0, termUi.ZkEVM))
+
+		topRowBlocks = append(topRowBlocks, ui.NewCol(1.0/5.0, termUi.Rollup))
 	}
 
 	termUi.TxPerBlockChart = widgets.NewSparkline()

--- a/util/util.go
+++ b/util/util.go
@@ -232,12 +232,26 @@ func GetZkEVMBatches(rpc *ethrpc.Client) (uint64, uint64, uint64, error) {
 	return trustedBatches, virtualBatches, verifiedBatches, nil
 }
 
+func GetForkID(rpc *ethrpc.Client) (uint64, error) {
+	var raw interface{}
+	if err := rpc.Call(&raw, string(forkID)); err != nil {
+		return 0, err
+	}
+	forkID, err := hexutil.DecodeUint64(fmt.Sprintf("%v", raw))
+	if err != nil {
+		return 0, err
+	}
+	return forkID, nil
+}
+
 type batch string
 
 const (
 	trusted  batch = "zkevm_batchNumber"
 	virtual  batch = "zkevm_virtualBatchNumber"
 	verified batch = "zkevm_verifiedBatchNumber"
+
+	forkID = "zkevm_getForkId"
 )
 
 func getZkEVMBatch(rpc *ethrpc.Client, batchType batch) (uint64, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -234,7 +234,7 @@ func GetZkEVMBatches(rpc *ethrpc.Client) (uint64, uint64, uint64, error) {
 
 func GetForkID(rpc *ethrpc.Client) (uint64, error) {
 	var raw interface{}
-	if err := rpc.Call(&raw, string(forkID)); err != nil {
+	if err := rpc.Call(&raw, "zkevm_getForkId"); err != nil {
 		return 0, err
 	}
 	forkID, err := hexutil.DecodeUint64(fmt.Sprintf("%v", raw))
@@ -250,8 +250,6 @@ const (
 	trusted  batch = "zkevm_batchNumber"
 	virtual  batch = "zkevm_virtualBatchNumber"
 	verified batch = "zkevm_verifiedBatchNumber"
-
-	forkID = "zkevm_getForkId"
 )
 
 func getZkEVMBatch(rpc *ethrpc.Client, batchType batch) (uint64, error) {


### PR DESCRIPTION
# Description

This PR introduces a new monitor section which currently shows the ForkID. In the future, the same section could be used to add more on-chain information including the:
- Rollup address
- Rollup manager address

This will allow users to easily identify these information in a single UI.

# Testing

![image](https://github.com/user-attachments/assets/46a14733-f1c7-4b62-852f-3cec18f78be0)


