### PR TITLE
feat: add rollup address and rollup manager address in monitor

### DIFF
--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -66,9 +66,11 @@ func GetZkEVMText(widget *widgets.Paragraph, trustedBatchesCount, virtualBatches
 	return formatParagraph(widget, []string{trustedBatches, virtualBatches, verifiedBatches})
 }
 
-func GetRollupText(widget *widgets.Paragraph, forkID uint64) string {
+func GetRollupText(widget *widgets.Paragraph, forkID uint64, rollupAddress string, rollupManagerAddress string) string {
 	forkIDString := fmt.Sprintf("ForkID:  %d", forkID)
-	return formatParagraph(widget, []string{forkIDString})
+	rollupAddressString := "RollupAddress: " + rollupAddress
+	rollupManagerAddressString := "RollupManagerAddress: " + rollupManagerAddress
+	return formatParagraph(widget, []string{forkIDString, rollupAddressString, rollupManagerAddressString})
 }
 
 func formatParagraph(widget *widgets.Paragraph, content []string) string {

--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -68,8 +68,9 @@ func GetZkEVMText(widget *widgets.Paragraph, trustedBatchesCount, virtualBatches
 
 func GetRollupText(widget *widgets.Paragraph, forkID uint64, rollupAddress string, rollupManagerAddress string) string {
 	forkIDString := fmt.Sprintf("ForkID:  %d", forkID)
-	rollupAddressString := "RollupAddress: " + rollupAddress
-	rollupManagerAddressString := "RollupManagerAddress: " + rollupManagerAddress
+	rollupAddressString := fmt.Sprintf("RollupAddress:  %s", rollupAddress)
+	rollupManagerAddressString := fmt.Sprintf("RollupManagerAddress:  %s", rollupManagerAddress)
+
 	return formatParagraph(widget, []string{forkIDString, rollupAddressString, rollupManagerAddressString})
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -244,6 +244,26 @@ func GetForkID(rpc *ethrpc.Client) (uint64, error) {
 	return forkID, nil
 }
 
+func GetRollupAddress(rpc *ethrpc.Client) (string, error) {
+	var raw interface{}
+	if err := rpc.Call(&raw, "zkevm_getRollupAddress"); err != nil {
+		return "", err
+	}
+	rollupAddress := fmt.Sprintf("%v", raw)
+
+	return rollupAddress, nil
+}
+
+func GetRollupManagerAddress(rpc *ethrpc.Client) (string, error) {
+	var raw interface{}
+	if err := rpc.Call(&raw, "zkevm_getRollupManagerAddress"); err != nil {
+		return "", err
+	}
+	rollupManagerAddress := fmt.Sprintf("%v", raw)
+
+	return rollupManagerAddress, nil
+}
+
 type batch string
 
 const (


### PR DESCRIPTION
# Description

This PR adds two additional metrics to the monitor UI, following #429 :
- Rollup Address
- Rollup Manager Address

The above addresses are retrieved by using the new [zkEVM API calls](https://github.com/0xPolygonHermez/cdk-erigon/pull/1447). This will only work on CDK Erigon images which have that PR merged in.

# Testing
Tested locally with Kurtosis  CDK
![image](https://github.com/user-attachments/assets/b5820d00-ba95-4cd4-8567-89953d5b27ff)

