### PR TITLE
fix: cross compile when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ cross: $(BUILD_DIR) ## Cross-compile go binaries using CGO.
 # - `-linkmode external -extldflags "-static-libgo"` allows dynamic linking.
 	echo "Building $(BIN_NAME)_$(GIT_TAG)_linux_arm64..."
 	CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOOS=linux GOARCH=arm64 go build \
-			-ldflags '$(VERSION_FLAGS) -s -w -linkmode external -extldflags "-static-libgo"' \
+			-ldflags '$(VERSION_FLAGS) -s -w -linkmode external -extldflags "-static"' \
 			-tags netgo \
 			-o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_arm64 \
 			main.go
 
 	echo "Building $(BIN_NAME)_$(GIT_TAG)_linux_amd64..."
 	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
-			-ldflags '$(VERSION_FLAGS) -s -w -linkmode external -extldflags "-static-libgo"' \
+			-ldflags '$(VERSION_FLAGS) -s -w -linkmode external -extldflags "-static"' \
 			-tags netgo \
 			-o $(BUILD_DIR)/$(BIN_NAME)_$(GIT_TAG)_linux_amd64 \
 			main.go


### PR DESCRIPTION
# Description

When tagging a new release, the current CI suddenly seems to be [failing](https://github.com/0xPolygon/polygon-cli/actions/runs/12800970614/job/35692249637). This PR changes the `-static-libgo` flag to `-static` which allows the cross build to [pass](https://github.com/jhkimqd/polygon-cli/actions/runs/12803011877/job/35695011052).