### PR TITLE
fix: adding back missing arg

### DIFF
--- a/cmd/ulxly/ulxly.go
+++ b/cmd/ulxly/ulxly.go
@@ -1419,6 +1419,7 @@ or if it's actually an intermediate hash.`,
 	inputUlxlyArgs.destNetwork = ulxlyBridgeCmd.PersistentFlags().Uint32(ArgDestNetwork, 0, "the rollup id of the destination network")
 	inputUlxlyArgs.tokenAddress = ulxlyBridgeCmd.PersistentFlags().String(ArgTokenAddress, "0x0000000000000000000000000000000000000000", "the address of an ERC20 token to be used")
 	inputUlxlyArgs.callData = ulxlyBridgeCmd.PersistentFlags().String(ArgCallData, "0x", "call data to be passed directly with bridge-message or as an ERC20 Permit")
+	inputUlxlyArgs.callDataFile = ulxlyBridgeCmd.PersistentFlags().String(ArgCallDataFile, "", "a file containing hex encoded call data")
 	fatalIfError(ulxlyBridgeCmd.MarkPersistentFlagRequired(ArgDestNetwork))
 
 	// Claim specific args

--- a/doc/polycli_ulxly__bridge.md
+++ b/doc/polycli_ulxly__bridge.md
@@ -17,6 +17,7 @@ Commands for moving funds and sending messages from one chain to another
 
 ```bash
       --call-data string             call data to be passed directly with bridge-message or as an ERC20 Permit (default "0x")
+      --call-data-file string        a file containing hex encoded call data
       --destination-network uint32   the rollup id of the destination network
       --force-update-root            indicates if the new global exit root is updated or not (default true)
   -h, --help                         help for bridge

--- a/doc/polycli_ulxly__bridge_asset.md
+++ b/doc/polycli_ulxly__bridge_asset.md
@@ -100,6 +100,7 @@ The command also inherits flags from parent commands.
 ```bash
       --bridge-address string              the address of the lxly bridge
       --call-data string                   call data to be passed directly with bridge-message or as an ERC20 Permit (default "0x")
+      --call-data-file string              a file containing hex encoded call data
       --chain-id string                    set the chain id to be used in the transaction
       --config string                      config file (default is $HOME/.polygon-cli.yaml)
       --destination-address string         the address where the bridge will be sent to

--- a/doc/polycli_ulxly__bridge_message.md
+++ b/doc/polycli_ulxly__bridge_message.md
@@ -97,6 +97,7 @@ The command also inherits flags from parent commands.
 ```bash
       --bridge-address string              the address of the lxly bridge
       --call-data string                   call data to be passed directly with bridge-message or as an ERC20 Permit (default "0x")
+      --call-data-file string              a file containing hex encoded call data
       --chain-id string                    set the chain id to be used in the transaction
       --config string                      config file (default is $HOME/.polygon-cli.yaml)
       --destination-address string         the address where the bridge will be sent to

--- a/doc/polycli_ulxly__bridge_weth.md
+++ b/doc/polycli_ulxly__bridge_weth.md
@@ -66,6 +66,7 @@ The command also inherits flags from parent commands.
 ```bash
       --bridge-address string              the address of the lxly bridge
       --call-data string                   call data to be passed directly with bridge-message or as an ERC20 Permit (default "0x")
+      --call-data-file string              a file containing hex encoded call data
       --chain-id string                    set the chain id to be used in the transaction
       --config string                      config file (default is $HOME/.polygon-cli.yaml)
       --destination-address string         the address where the bridge will be sent to


### PR DESCRIPTION
# Description

The `calldata-file` arg was dropped in a bad merge. Adding it back.
