### PR TITLE
ecrecover for transactions

### DIFF
--- a/doc/polycli_ecrecover.md
+++ b/doc/polycli_ecrecover.md
@@ -44,11 +44,11 @@ JSON Data passed in follows object definition [here](https://www.quicknode.com/d
 ## Flags
 
 ```bash
-  -b, --block-number uint    Block number to check the extra data for (default: latest)
-  -f, --file string          Path to a file containing block information in JSON format
-  -h, --help                 help for ecrecover
-  -r, --rpc-url string       The RPC endpoint url
-  -t, --transaction string   Transaction hash in hex format
+  -b, --block-number uint   Block number to check the extra data for (default: latest)
+  -f, --file string         Path to a file containing block information in JSON format
+  -h, --help                help for ecrecover
+  -r, --rpc-url string      The RPC endpoint url
+  -t, --tx string           Transaction data in hex format
 ```
 
 The command also inherits flags from parent commands.

--- a/doc/polycli_ecrecover.md
+++ b/doc/polycli_ecrecover.md
@@ -44,10 +44,11 @@ JSON Data passed in follows object definition [here](https://www.quicknode.com/d
 ## Flags
 
 ```bash
-  -b, --block-number uint   Block number to check the extra data for (default: latest)
-  -f, --file string         Path to a file containing block information in JSON format
-  -h, --help                help for ecrecover
-  -r, --rpc-url string      The RPC endpoint url
+  -b, --block-number uint    Block number to check the extra data for (default: latest)
+  -f, --file string          Path to a file containing block information in JSON format
+  -h, --help                 help for ecrecover
+  -r, --rpc-url string       The RPC endpoint url
+  -t, --transaction string   Transaction hash in hex format
 ```
 
 The command also inherits flags from parent commands.

--- a/util/util.go
+++ b/util/util.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
-	"reflect"
 
 	"github.com/cenkalti/backoff"
 	"github.com/ethereum/go-ethereum/common/hexutil"

--- a/util/util.go
+++ b/util/util.go
@@ -50,6 +50,16 @@ func Ecrecover(block *types.Block) ([]byte, error) {
 	return signer, nil
 }
 
+func EcrecoverTx(tx *types.Transaction) ([]byte, error) {
+	chainID := tx.ChainId()
+	signer := types.LatestSignerForChainID(chainID)
+	from, err := types.Sender(signer, tx)
+	if err != nil {
+		return nil, err
+	}
+	return from.Bytes(), nil
+}
+
 func GetBlockRange(ctx context.Context, from, to uint64, c *ethrpc.Client) ([]*json.RawMessage, error) {
 	blms := make([]ethrpc.BatchElem, 0)
 	for i := from; i <= to; i = i + 1 {


### PR DESCRIPTION
# Description

Adds --tx option to ecrecover by transaction (hex format). It is exclusive with --block-number and --file. Also, --file is exclusive with --rpc-url

## Jira / Linear Tickets

https://github.com/orgs/0xPolygon/projects/13/views/6?pane=issue&itemId=94575989

# Testing

### Positive case

```
polycli ecrecover --tx 
0x02f86e8205390284014740d385174876e800830186a09400000000000000000000000000000000000000000180c001a05850bab315b686a2bee6ba91b869867ca2f25e612d9ee771588e9efd10a4d3b8a0157972512263193e7a96f2
2c2269691733012d98cd715a9528fed02003260198
```

### Old cases still work

```
polycli ecrecover --rpc-url https://polygon-rpc.com -b 12345678
0x0375b2fc7140977c9c76D45421564e354ED42277
```

### Error cases

```
polycli ecrecover -t 0xdeadbeef
10:24AM ERR Unable to decode transaction error="rlp: value size exceeds available input length"
```

```
polycli ecrecover --rpc-url https://polygon-rpc.com -t 0xdeadbeef -b 1
Error: if any flags in the group [file block-number tx] are set none of the others can be; [block-number tx] were all set
```

```
polycli ecrecover -f ./somepath -t 0xdeadbeef
Error: if any flags in the group [file block-number tx] are set none of the others can be; [file tx] were all set
```


