### PR TITLE
improve invalid --private-key error

### DIFF
--- a/cmd/ulxly/ulxly.go
+++ b/cmd/ulxly/ulxly.go
@@ -1314,11 +1314,11 @@ func prepInputs(cmd *cobra.Command, args []string) error {
 		inputUlxlyArgs.gasLimit = &dryRunGasLimit
 	}
 	pvtKey := strings.TrimPrefix(*inputUlxlyArgs.privateKey, "0x")
-
 	privateKey, err := crypto.HexToECDSA(pvtKey)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid --%s: %w", ArgPrivateKey, err)
 	}
+
 	publicKey := privateKey.Public()
 
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)


### PR DESCRIPTION
closes https://github.com/0xPolygon/devtools/issues/82

improve invalid `--private-key` error for `ulxly` commands
