### PR TITLE
fix: monitor pagedown panic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
       - name: Install shadow
         run: go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
       - name: Run all the linter tools against code

--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -509,6 +509,14 @@ func renderMonitorUI(ctx context.Context, ec *ethclient.Client, ms *monitorStatu
 			termui.Render(selectGrid)
 			return
 		} else if currentMode == monitorModeBlock {
+			if ms.SelectedBlock == nil {
+				currentMode = monitorModeExplorer
+				blockTable.SelectedRow = 0
+				termui.Clear()
+				termui.Render(grid)
+				return
+			}
+
 			// render a block
 			skeleton.BlockInfo.Rows = ui.GetSimpleBlockFields(ms.SelectedBlock)
 			rows, title := ui.GetTransactionsList(ms.SelectedBlock, ms.ChainID)

--- a/cmd/monitor/ui/ui.go
+++ b/cmd/monitor/ui/ui.go
@@ -276,6 +276,10 @@ func GetSelectedBlocksList(blocks []rpctypes.PolyBlock) ([]string, string) {
 }
 
 func GetSimpleBlockFields(block rpctypes.PolyBlock) []string {
+	if block == nil {
+		return []string{}
+	}
+
 	ts := block.Time()
 	ut := time.Unix(int64(ts), 0)
 


### PR DESCRIPTION
closes https://github.com/0xPolygon/polygon-cli/issues/543

It prevents the UI from panicking during the loading when the page-down key is pressed, and the selected block is not set yet.

extra:
- adds a mechanism to avoid calling the `peerCount` endpoint infinitely when its not available, there is not specific issue for that, but it follows the same idea as this https://github.com/0xPolygon/polygon-cli/issues/552