### PR TITLE
Fix Address Generation by Properly Left-Padding Public Key Coordinates

### DIFF
--- a/cmd/wallet/wallet.go
+++ b/cmd/wallet/wallet.go
@@ -132,7 +132,7 @@ func init() {
 	inputPassword = WalletCmd.PersistentFlags().String("password", "", "Password used along with the mnemonic")
 	inputPasswordFile = WalletCmd.PersistentFlags().String("password-file", "", "Password stored in a file used along with the mnemonic")
 	inputMnemonic = WalletCmd.PersistentFlags().String("mnemonic", "", "A mnemonic phrase used to generate entropy")
-	inputMnemonicFile = WalletCmd.PersistentFlags().String("mnemonic-file", "", "A mneomonic phrase written in a file used to generate entropy")
-	inputUseRawEntropy = WalletCmd.PersistentFlags().Bool("raw-entropy", false, "substrate and polkda dot don't follow strict bip39 and use raw entropy")
+	inputMnemonicFile = WalletCmd.PersistentFlags().String("mnemonic-file", "", "A mnemonic phrase written in a file used to generate entropy")
+	inputUseRawEntropy = WalletCmd.PersistentFlags().Bool("raw-entropy", false, "substrate and polka dot don't follow strict bip39 and use raw entropy")
 	inputRootOnly = WalletCmd.PersistentFlags().Bool("root-only", false, "don't produce HD accounts. Just produce a single wallet")
 }

--- a/doc/polycli_wallet.md
+++ b/doc/polycli_wallet.md
@@ -60,11 +60,11 @@ $ polycli wallet create --path "m/44'/0'/0'" --addresses 5
       --iterations uint        Number of pbkdf2 iterations to perform (default 2048)
       --language string        Which language to use [ChineseSimplified, ChineseTraditional, Czech, English, French, Italian, Japanese, Korean, Spanish] (default "english")
       --mnemonic string        A mnemonic phrase used to generate entropy
-      --mnemonic-file string   A mneomonic phrase written in a file used to generate entropy
+      --mnemonic-file string   A mnemonic phrase written in a file used to generate entropy
       --password string        Password used along with the mnemonic
       --password-file string   Password stored in a file used along with the mnemonic
       --path string            What would you like the derivation path to be (default "m/44'/60'/0'")
-      --raw-entropy            substrate and polkda dot don't follow strict bip39 and use raw entropy
+      --raw-entropy            substrate and polka dot don't follow strict bip39 and use raw entropy
       --root-only              don't produce HD accounts. Just produce a single wallet
       --words int              The number of words to use in the mnemonic (default 24)
 ```

--- a/hdwallet/hdwallet.go
+++ b/hdwallet/hdwallet.go
@@ -330,11 +330,23 @@ func RawPubKeyToETHAddress(concat []byte) common.Address {
 	b := h.Sum(nil)
 	return common.BytesToAddress(b)
 }
+
 func toUncompressedPubKey(prvKey *bip32.Key) []byte {
-	// the GetPublicKey method returns a compressed key so we'll manually get the public key from the curve
 	curve := secp256k1.S256()
 	x1, y1 := curve.ScalarBaseMult(prvKey.Key)
-	concat := append(x1.Bytes(), y1.Bytes()...)
+
+	// left-pad each coordinate to 32 bytes
+	xBytes := x1.Bytes()
+	yBytes := y1.Bytes()
+
+	paddedX := make([]byte, 32-len(xBytes), 32)
+	paddedX = append(paddedX, xBytes...)
+
+	paddedY := make([]byte, 32-len(yBytes), 32)
+	paddedY = append(paddedY, yBytes...)
+
+	// Then we just append them
+	concat := append(paddedX, paddedY...)
 	return concat
 }
 

--- a/hdwallet/hdwallet_test.go
+++ b/hdwallet/hdwallet_test.go
@@ -315,3 +315,33 @@ func TestGetPublicKeyFromSeed(t *testing.T) {
 	}
 
 }
+
+// https://github.com/0xPolygon/polygon-cli/issues/564
+func TestPaddedPublicKey(t *testing.T) {
+	pw, err := NewPolyWallet("cancel panther badge spell bleak summer hair cup frozen gossip tell element", "")
+	if err != nil {
+		t.Errorf("Failed to create new poly wallet: %v", err)
+	}
+	err = pw.SetPath("m/44'/60'/0'")
+	if err != nil {
+		t.Errorf("Failed setting derivation path failed: %v", err)
+	}
+	err = pw.SetIterations(2048)
+	if err != nil {
+		t.Errorf("Failed to set iteration count: %v", err)
+	}
+	err = pw.SetUseRawEntropy(false)
+	if err != nil {
+		t.Errorf("Failed to set raw entropy: %v", err)
+	}
+	key, err := pw.ExportHDAddresses(2)
+	if err != nil {
+		t.Errorf("Failed to export HD address %v", err)
+	}
+	if len(key.Addresses) != 2 {
+		t.Errorf("Expected 2 addresses to be exported and got %d", len(key.Addresses))
+	}
+	if key.Addresses[1].ETHAddress != "0x2CDfa87C022744CceABC525FaA8e85Df6984A60d" {
+		t.Errorf("Unexpected address. Expected 0x2CDfa87C022744CceABC525FaA8e85Df6984A60d and Got %s", key.Addresses[1].ETHAddress)
+	}
+}


### PR DESCRIPTION
# Description

This PR fixes a [bug](https://github.com/0xPolygon/polygon-cli/issues/564) in Ethereum address generation where the x or y coordinate of the public key could have leading zeros removed by big.Int.Bytes(). That led to occasional incorrect addresses. By left-padding each coordinate to 32 bytes, we ensure the uncompressed public key is always 64 bytes before hashing, yielding consistent and correct Ethereum addresses.


