### PR TITLE
ci: update concurrency setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 env:
   GO_VERSION: "1.24.1" # https://go.dev/dl/


### PR DESCRIPTION
The concurrency block in our workflows is used to prevent duplicate or overlapping runs for the same workflow and branch or PR. The issue was that this setup also cancelled previous jobs on the main branch, which was not intended. This PR updates the configuration so that job cancellation only happens for PRs, ensuring all runs on the main branch are preserved.

This PR removes the concurrency block from the nightly workflow, allowing multiple scheduled or manually triggered nightly runs to execute independently without cancelling each other.