### PR TITLE
feat: log calldata if revert

### DIFF
--- a/cmd/ulxly/ulxly.go
+++ b/cmd/ulxly/ulxly.go
@@ -737,6 +737,7 @@ func bridgeAsset(cmd *cobra.Command) error {
 
 	bridgeTxn, err := bridgeV2.BridgeAsset(auth, destinationNetwork, toAddress, value, tokenAddress, isForced, callData)
 	if err = logAndReturnJsonError(cmd, client, bridgeTxn, auth, err); err != nil {
+		log.Info().Err(err).Str("calldata", callDataString).Msg("Bridge transaction failed")
 		return err
 	}
 	log.Info().Msg("bridgeTxn: " + bridgeTxn.Hash().String())
@@ -790,6 +791,7 @@ func bridgeMessage(cmd *cobra.Command) error {
 
 	bridgeTxn, err := bridgeV2.BridgeMessage(auth, destinationNetwork, toAddress, isForced, callData)
 	if err = logAndReturnJsonError(cmd, client, bridgeTxn, auth, err); err != nil {
+		log.Info().Err(err).Str("calldata", callDataString).Msg("Bridge transaction failed")
 		return err
 	}
 	log.Info().Msg("bridgeTxn: " + bridgeTxn.Hash().String())
@@ -846,6 +848,7 @@ func bridgeWETHMessage(cmd *cobra.Command) error {
 
 	bridgeTxn, err := bridgeV2.BridgeMessageWETH(auth, destinationNetwork, toAddress, value, isForced, callData)
 	if err = logAndReturnJsonError(cmd, client, bridgeTxn, auth, err); err != nil {
+		log.Info().Err(err).Str("calldata", callDataString).Msg("Bridge transaction failed")
 		return err
 	}
 	log.Info().Msg("bridgeTxn: " + bridgeTxn.Hash().String())


### PR DESCRIPTION
# Description

- Log input calldata for `polycli ulxly bridge` command if the transaction is reverted

# Testing

Create a massive calldata file first with 
```
xxd -p /dev/zero | tr -d "\n" | head -c 97000 > /tmp/test.hex
```

Then trigger bridging with
```
polycli ulxly bridge asset --rpc-url http://$(kurtosis port print op el-1-geth-lighthouse rpc) --destination-network 1 --destination-address 0xE34aaF64b29273B7D567FCFc40544c014EEe9970 --token-address 0x22939b3A4dFD9Fc6211F99Cdc6bd9f6708ae2956 --call-data-file /tmp/test.hex --force-update-root=false --value 0 --bridge-address 0x927aa8656B3a541617Ef3fBa4A2AB71320dc7fD7 --private-key 12d7de8621a77640c9241b2595ba78ce443d05e94090365ab3bb5e19df82c625
```

![Screenshot from 2025-07-10 10-58-25](https://github.com/user-attachments/assets/40ad8731-40e9-4c48-aa07-1b78a9bf7a1b)
