### PR TITLE
loadtest clean-up

### DIFF
--- a/cmd/flag_loader/flag_loader.go
+++ b/cmd/flag_loader/flag_loader.go
@@ -2,8 +2,8 @@ package flag_loader
 
 import (
 	"fmt"
-	"os"
 	"math/big"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -14,24 +14,24 @@ const (
 )
 
 type BigIntValue struct {
-    Val *big.Int
+	Val *big.Int
 }
 
 func (b *BigIntValue) String() string {
-    // Return the decimal representation
-    return b.Val.String()
+	// Return the decimal representation
+	return b.Val.String()
 }
 
 func (b *BigIntValue) Set(s string) error {
-    // Parse the string in base 10
-    if _, ok := b.Val.SetString(s, 10); !ok {
-        return fmt.Errorf("invalid big integer: %q", s)
-    }
-    return nil
+	// Parse the string in base 10
+	if _, ok := b.Val.SetString(s, 10); !ok {
+		return fmt.Errorf("invalid big integer: %q", s)
+	}
+	return nil
 }
 
 func (b *BigIntValue) Type() string {
-    return "big.Int"
+	return "big.Int"
 }
 
 func GetRpcUrlFlagValue(cmd *cobra.Command) *string {

--- a/cmd/fund/cmd.go
+++ b/cmd/fund/cmd.go
@@ -36,8 +36,8 @@ type cmdFundParams struct {
 
 var (
 	//go:embed usage.md
-	usage  string
-	params cmdFundParams
+	usage               string
+	params              cmdFundParams
 	defaultFundingInWei = big.NewInt(50000000000000000) // 0.05 ETH
 )
 
@@ -70,7 +70,7 @@ func init() {
 	p.UseHDDerivation = flagSet.Bool("hd-derivation", true, "Derive wallets to fund from the private key in a deterministic way")
 	p.WalletAddresses = flagSet.StringSlice("addresses", nil, "Comma-separated list of wallet addresses to fund")
 	p.FundingAmountInWei = defaultFundingInWei
-	flagSet.Var(&flag_loader.BigIntValue{Val: p.FundingAmountInWei }, "eth-amount", "The amount of wei to send to each wallet")
+	flagSet.Var(&flag_loader.BigIntValue{Val: p.FundingAmountInWei}, "eth-amount", "The amount of wei to send to each wallet")
 
 	p.OutputFile = flagSet.StringP("file", "f", "wallets.json", "The output JSON file path for storing the addresses and private keys of funded wallets")
 

--- a/cmd/loadtest/account.go
+++ b/cmd/loadtest/account.go
@@ -744,7 +744,7 @@ func (ap *AccountPool) Next(ctx context.Context) (Account, error) {
 	account := ap.accounts[ap.currentAccountIndex]
 
 	// if test is call only, there is no need to fund accounts, return it
-	if !*inputLoadTestParams.CallOnly {
+	if !*inputLoadTestParams.EthCallOnly {
 		_, err := ap.fundAccountIfNeeded(ctx, account, nil, true)
 		if err != nil {
 			return Account{}, err

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -62,7 +62,7 @@ type (
 		ERC20Address                  *string
 		ERC721Address                 *string
 		DelAddress                    *string
-		ForceContractDeploy           *bool
+		SkipContractDeploy            *bool
 		ForceGasLimit                 *uint64
 		ForceGasPrice                 *uint64
 		ForcePriorityGasPrice         *uint64
@@ -83,7 +83,7 @@ type (
 		SendingAddressCount           *uint64
 		AddressFundingAmount          *big.Int
 		PreFundSendingAddresses       *bool
-		KeepFundedAmount              *bool
+		KeepFundsAfterTest            *bool
 		SendingAddressesFile          *string
 		Proxy                         *string
 
@@ -246,7 +246,7 @@ func initFlags() {
 	ltp.AddressFundingAmount = defaultFunding
 	LoadtestCmd.Flags().Var(&flag_loader.BigIntValue{Val: ltp.AddressFundingAmount}, "address-funding-amount", "The amount in wei to fund the sending addresses with. Set to 0 to disable account funding (useful for call-only mode or pre-funded addresses).")
 	ltp.PreFundSendingAddresses = LoadtestCmd.Flags().Bool("pre-fund-sending-addresses", false, "If set to true, the sending addresses will be funded at the start of the execution, otherwise all addresses will be funded when used for the first time.")
-	ltp.KeepFundedAmount = LoadtestCmd.Flags().Bool("keep-funded-amount", false, "If set to true, the funded amount will be kept in the sending addresses. Otherwise, the funded amount will be refunded back to the account used to fund the account.")
+	ltp.KeepFundsAfterTest = LoadtestCmd.Flags().Bool("keep-funds-after-test", false, "If set to true, the funded amount will be kept in the sending addresses. Otherwise, the funded amount will be refunded back to the account used to fund the account.")
 	ltp.SendingAddressesFile = LoadtestCmd.Flags().String("sending-addresses-file", "", "The file containing the sending addresses private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending addresses for different execution cycles.")
 
 	// Local flags.
@@ -269,7 +269,7 @@ v3, uniswapv3 - Perform UniswapV3 swaps`)
 	ltp.LoadtestContractAddress = LoadtestCmd.Flags().String("loadtest-contract-address", "", "The address of a pre-deployed load test contract")
 	ltp.ERC20Address = LoadtestCmd.Flags().String("erc20-address", "", "The address of a pre-deployed ERC20 contract")
 	ltp.ERC721Address = LoadtestCmd.Flags().String("erc721-address", "", "The address of a pre-deployed ERC721 contract")
-	ltp.ForceContractDeploy = LoadtestCmd.Flags().Bool("force-contract-deploy", false, "Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.")
+	ltp.SkipContractDeploy = LoadtestCmd.Flags().Bool("skip-contract-deploy", true, "Some load test modes don't require a contract deployment. Set this flag to true(default) to skip contract deployments. This will still respect the --loadtest-contract-address flags.")
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in --mode contract-call. This must be paired up with --mode contract-call and --calldata")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -57,9 +57,9 @@ type (
 		AdaptiveBackoffFactor         *float64
 		Modes                         *[]string
 		Iterations                    *uint64
-		ByteCount                     *uint64
+		StoreDataSize                 *uint64
 		Seed                          *int64
-		LtAddress                     *string
+		LoadtestContractAddress       *string
 		ERC20Address                  *string
 		ERC721Address                 *string
 		DelAddress                    *string
@@ -267,8 +267,8 @@ rpc - Call random rpc methods
 s, store - Store bytes in a dynamic byte array
 t, transaction - Send transactions
 v3, uniswapv3 - Perform UniswapV3 swaps`)
-	ltp.ByteCount = LoadtestCmd.Flags().Uint64P("byte-count", "b", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
-	ltp.LtAddress = LoadtestCmd.Flags().String("loadtest-contract-address", "", "The address of a pre-deployed load test contract")
+	ltp.StoreDataSize = LoadtestCmd.Flags().Uint64("store-data-size", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
+	ltp.LoadtestContractAddress = LoadtestCmd.Flags().String("loadtest-contract-address", "", "The address of a pre-deployed load test contract")
 	ltp.ERC20Address = LoadtestCmd.Flags().String("erc20-address", "", "The address of a pre-deployed ERC20 contract")
 	ltp.ERC721Address = LoadtestCmd.Flags().String("erc721-address", "", "The address of a pre-deployed ERC721 contract")
 	ltp.ForceContractDeploy = LoadtestCmd.Flags().Bool("force-contract-deploy", false, "Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -70,7 +70,7 @@ type (
 		ShouldProduceSummary          *bool
 		SummaryOutputMode             *string
 		LegacyTransactionMode         *bool
-		SendOnly                      *bool
+		FireAndForget                 *bool
 		RecallLength                  *uint64
 		ContractAddress               *string
 		ContractCallData              *string
@@ -242,7 +242,7 @@ func initFlags() {
 	ltp.BatchSize = LoadtestCmd.PersistentFlags().Uint64("batch-size", 999, "Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time.")
 	ltp.SummaryOutputMode = LoadtestCmd.PersistentFlags().String("output-mode", "text", "Format mode for summary output (json | text)")
 	ltp.LegacyTransactionMode = LoadtestCmd.PersistentFlags().Bool("legacy", false, "Send a legacy transaction instead of an EIP1559 transaction.")
-	ltp.SendOnly = LoadtestCmd.PersistentFlags().Bool("send-only", false, "Send transactions and load without waiting for it to be mined.")
+	ltp.FireAndForget = LoadtestCmd.PersistentFlags().Bool("fire-and-forget", false, "Send transactions and load without waiting for it to be mined.")
 	ltp.BlobFeeCap = LoadtestCmd.Flags().Uint64("blob-fee-cap", 100000, "The blob fee cap, or the maximum blob fee per chunk, in Gwei.")
 	ltp.SendingAddressCount = LoadtestCmd.Flags().Uint64("sending-address-count", 1, "The number of sending addresses to use. This is useful for avoiding pool account queue.")
 	ltp.AddressFundingAmount = defaultFunding

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -43,8 +43,8 @@ type (
 		BatchSize                     *uint64
 		TimeLimit                     *int64
 		ToRandom                      *bool
-		CallOnly                      *bool
-		CallOnlyLatestBlock           *bool
+		EthCallOnly                   *bool
+		EthCallOnlyLatestBlock        *bool
 		ChainID                       *uint64
 		PrivateKey                    *string
 		ToAddress                     *string
@@ -222,8 +222,8 @@ func initFlags() {
 	ltp.ChainID = LoadtestCmd.PersistentFlags().Uint64("chain-id", 0, "The chain id for the transactions.")
 	ltp.ToAddress = LoadtestCmd.PersistentFlags().String("to-address", "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF", "The address that we're going to send to")
 	ltp.ToRandom = LoadtestCmd.PersistentFlags().Bool("to-random", false, "When doing a transfer test, should we send to random addresses rather than DEADBEEFx5")
-	ltp.CallOnly = LoadtestCmd.PersistentFlags().Bool("call-only", false, "When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.")
-	ltp.CallOnlyLatestBlock = LoadtestCmd.PersistentFlags().Bool("call-only-latest", false, "When using call only mode with recall, should we execute on the latest block or on the original block")
+	ltp.EthCallOnly = LoadtestCmd.PersistentFlags().Bool("eth-call-only", false, "When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.")
+	ltp.EthCallOnlyLatestBlock = LoadtestCmd.PersistentFlags().Bool("call-only-latest", false, "When using call only mode with recall, should we execute on the latest block or on the original block")
 	ltp.EthAmountInWei = LoadtestCmd.PersistentFlags().Uint64("eth-amount-in-wei", 0, "The amount of ether in wei to send on every transaction")
 	ltp.RateLimit = LoadtestCmd.PersistentFlags().Float64("rate-limit", 4, "An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together")
 	ltp.AdaptiveRateLimit = LoadtestCmd.PersistentFlags().Bool("adaptive-rate-limit", false, "Enable AIMD-style congestion control to automatically adjust request rate")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -51,7 +51,7 @@ type (
 		EthAmountInWei                *uint64
 		RateLimit                     *float64
 		AdaptiveRateLimit             *bool
-		SteadyStateTxPoolSize         *uint64
+		AdaptiveTargetSize            *uint64
 		AdaptiveRateLimitIncrement    *uint64
 		AdaptiveCycleDuration         *uint64
 		AdaptiveBackoffFactor         *float64
@@ -227,7 +227,7 @@ func initFlags() {
 	ltp.EthAmountInWei = LoadtestCmd.PersistentFlags().Uint64("eth-amount-in-wei", 0, "The amount of ether in wei to send on every transaction")
 	ltp.RateLimit = LoadtestCmd.PersistentFlags().Float64("rate-limit", 4, "An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together")
 	ltp.AdaptiveRateLimit = LoadtestCmd.PersistentFlags().Bool("adaptive-rate-limit", false, "Enable AIMD-style congestion control to automatically adjust request rate")
-	ltp.SteadyStateTxPoolSize = LoadtestCmd.PersistentFlags().Uint64("steady-state-tx-pool-size", 1000, "When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off.")
+	ltp.AdaptiveTargetSize = LoadtestCmd.PersistentFlags().Uint64("adaptive-target-size", 1000, "When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off.")
 	ltp.AdaptiveRateLimitIncrement = LoadtestCmd.PersistentFlags().Uint64("adaptive-rate-limit-increment", 50, "When using adaptive rate limiting, this flag controls the size of the additive increases.")
 	ltp.AdaptiveCycleDuration = LoadtestCmd.PersistentFlags().Uint64("adaptive-cycle-duration-seconds", 10, "When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates")
 	ltp.AdaptiveBackoffFactor = LoadtestCmd.PersistentFlags().Float64("adaptive-backoff-factor", 2, "When using adaptive rate limiting, this flag controls our multiplicative decrease value.")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -62,7 +62,6 @@ type (
 		ERC20Address                  *string
 		ERC721Address                 *string
 		DelAddress                    *string
-		SkipContractDeploy            *bool
 		ForceGasLimit                 *uint64
 		ForceGasPrice                 *uint64
 		ForcePriorityGasPrice         *uint64
@@ -269,7 +268,6 @@ v3, uniswapv3 - Perform UniswapV3 swaps`)
 	ltp.LoadtestContractAddress = LoadtestCmd.Flags().String("loadtest-contract-address", "", "The address of a pre-deployed load test contract")
 	ltp.ERC20Address = LoadtestCmd.Flags().String("erc20-address", "", "The address of a pre-deployed ERC20 contract")
 	ltp.ERC721Address = LoadtestCmd.Flags().String("erc721-address", "", "The address of a pre-deployed ERC721 contract")
-	ltp.SkipContractDeploy = LoadtestCmd.Flags().Bool("skip-contract-deploy", true, "Some load test modes don't require a contract deployment. Set this flag to true(default) to skip contract deployments. This will still respect the --loadtest-contract-address flags.")
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in --mode contract-call. This must be paired up with --mode contract-call and --calldata")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -56,7 +56,6 @@ type (
 		AdaptiveCycleDuration         *uint64
 		AdaptiveBackoffFactor         *float64
 		Modes                         *[]string
-		Iterations                    *uint64
 		StoreDataSize                 *uint64
 		Seed                          *int64
 		LoadtestContractAddress       *string
@@ -223,7 +222,7 @@ func initFlags() {
 	ltp.ToAddress = LoadtestCmd.PersistentFlags().String("to-address", "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF", "The address that we're going to send to")
 	ltp.ToRandom = LoadtestCmd.PersistentFlags().Bool("to-random", false, "When doing a transfer test, should we send to random addresses rather than DEADBEEFx5")
 	ltp.EthCallOnly = LoadtestCmd.PersistentFlags().Bool("eth-call-only", false, "When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.")
-	ltp.EthCallOnlyLatestBlock = LoadtestCmd.PersistentFlags().Bool("call-only-latest", false, "When using call only mode with recall, should we execute on the latest block or on the original block")
+	ltp.EthCallOnlyLatestBlock = LoadtestCmd.PersistentFlags().Bool("eth-call-only-latest", false, "When using call only mode with recall, should we execute on the latest block or on the original block")
 	ltp.EthAmountInWei = LoadtestCmd.PersistentFlags().Uint64("eth-amount-in-wei", 0, "The amount of ether in wei to send on every transaction")
 	ltp.RateLimit = LoadtestCmd.PersistentFlags().Float64("rate-limit", 4, "An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together")
 	ltp.AdaptiveRateLimit = LoadtestCmd.PersistentFlags().Bool("adaptive-rate-limit", false, "Enable AIMD-style congestion control to automatically adjust request rate")
@@ -232,7 +231,6 @@ func initFlags() {
 	ltp.AdaptiveCycleDuration = LoadtestCmd.PersistentFlags().Uint64("adaptive-cycle-duration-seconds", 10, "When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates")
 	ltp.AdaptiveBackoffFactor = LoadtestCmd.PersistentFlags().Float64("adaptive-backoff-factor", 2, "When using adaptive rate limiting, this flag controls our multiplicative decrease value.")
 	ltp.GasPriceMultiplier = LoadtestCmd.PersistentFlags().Float64("gas-price-multiplier", 1, "A multiplier to increase or decrease the gas price")
-	ltp.Iterations = LoadtestCmd.PersistentFlags().Uint64P("iterations", "i", 1, "If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size")
 	ltp.Seed = LoadtestCmd.PersistentFlags().Int64("seed", 123456, "A seed for generating random values and addresses")
 	ltp.ForceGasLimit = LoadtestCmd.PersistentFlags().Uint64("gas-limit", 0, "In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas")
 	ltp.ForceGasPrice = LoadtestCmd.PersistentFlags().Uint64("gas-price", 0, "In environments where the gas price can't be determined automatically, we can specify it manually")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -268,10 +268,10 @@ s, store - Store bytes in a dynamic byte array
 t, transaction - Send transactions
 v3, uniswapv3 - Perform UniswapV3 swaps`)
 	ltp.ByteCount = LoadtestCmd.Flags().Uint64P("byte-count", "b", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
-	ltp.LtAddress = LoadtestCmd.Flags().String("lt-address", "", "The address of a pre-deployed load test contract")
+	ltp.LtAddress = LoadtestCmd.Flags().String("loadtest-contract-address", "", "The address of a pre-deployed load test contract")
 	ltp.ERC20Address = LoadtestCmd.Flags().String("erc20-address", "", "The address of a pre-deployed ERC20 contract")
 	ltp.ERC721Address = LoadtestCmd.Flags().String("erc721-address", "", "The address of a pre-deployed ERC721 contract")
-	ltp.ForceContractDeploy = LoadtestCmd.Flags().Bool("force-contract-deploy", false, "Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.")
+	ltp.ForceContractDeploy = LoadtestCmd.Flags().Bool("force-contract-deploy", false, "Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.")
 	ltp.RecallLength = LoadtestCmd.Flags().Uint64("recall-blocks", 50, "The number of blocks that we'll attempt to fetch for recall")
 	ltp.ContractAddress = LoadtestCmd.Flags().String("contract-address", "", "The address of the contract that will be used in --mode contract-call. This must be paired up with --mode contract-call and --calldata")
 	ltp.ContractCallData = LoadtestCmd.Flags().String("calldata", "", "The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -56,7 +56,6 @@ type (
 		AdaptiveCycleDuration         *uint64
 		AdaptiveBackoffFactor         *float64
 		Modes                         *[]string
-		Function                      *uint64
 		Iterations                    *uint64
 		ByteCount                     *uint64
 		Seed                          *int64
@@ -260,18 +259,14 @@ b, blob - Send blob transactions
 c, call - Call random contract functions
 cc, contract-call - Make contract calls
 d, deploy - Deploy contracts
-f, function - Call random contract functions
 i, inscription - Send inscription transactions
 inc, increment - Increment a counter
-pr, random-precompile - Call random precompiled contracts
-px, specific-precompile - Call specific precompiled contracts
 r, random - Random modes (does not include the following modes: blob, call, inscription, recall, rpc, uniswapv3)
 R, recall - Replay or simulate transactions
 rpc - Call random rpc methods
 s, store - Store bytes in a dynamic byte array
 t, transaction - Send transactions
 v3, uniswapv3 - Perform UniswapV3 swaps`)
-	ltp.Function = LoadtestCmd.Flags().Uint64P("function", "f", 1, "A specific function to be called if running with --mode f or a specific precompiled contract when running with --mode a")
 	ltp.ByteCount = LoadtestCmd.Flags().Uint64P("byte-count", "b", 1024, "If we're in store mode, this controls how many bytes we'll try to store in our contract")
 	ltp.LtAddress = LoadtestCmd.Flags().String("lt-address", "", "The address of a pre-deployed load test contract")
 	ltp.ERC20Address = LoadtestCmd.Flags().String("erc20-address", "", "The address of a pre-deployed ERC20 contract")

--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -42,7 +42,7 @@ type (
 		Concurrency                   *int64
 		BatchSize                     *uint64
 		TimeLimit                     *int64
-		ToRandom                      *bool
+		RandomRecipients              *bool
 		EthCallOnly                   *bool
 		EthCallOnlyLatestBlock        *bool
 		ChainID                       *uint64
@@ -220,7 +220,7 @@ func initFlags() {
 	ltp.PrivateKey = LoadtestCmd.PersistentFlags().String("private-key", codeQualityPrivateKey, "The hex encoded private key that we'll use to send transactions")
 	ltp.ChainID = LoadtestCmd.PersistentFlags().Uint64("chain-id", 0, "The chain id for the transactions.")
 	ltp.ToAddress = LoadtestCmd.PersistentFlags().String("to-address", "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF", "The address that we're going to send to")
-	ltp.ToRandom = LoadtestCmd.PersistentFlags().Bool("to-random", false, "When doing a transfer test, should we send to random addresses rather than DEADBEEFx5")
+	ltp.RandomRecipients = LoadtestCmd.PersistentFlags().Bool("random-recipients", false, "When doing a transfer test, should we send to random addresses rather than DEADBEEFx5")
 	ltp.EthCallOnly = LoadtestCmd.PersistentFlags().Bool("eth-call-only", false, "When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.")
 	ltp.EthCallOnlyLatestBlock = LoadtestCmd.PersistentFlags().Bool("eth-call-only-latest", false, "When using call only mode with recall, should we execute on the latest block or on the original block")
 	ltp.EthAmountInWei = LoadtestCmd.PersistentFlags().Uint64("eth-amount-in-wei", 0, "The amount of ether in wei to send on every transaction")

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -677,7 +677,8 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	// deploy and instantiate the load tester contract
 	var ltAddr ethcommon.Address
 	var ltContract *tester.LoadTester
-	if anyModeRequiresLoadTestContract(ltp.ParsedModes) || *inputLoadTestParams.ForceContractDeploy {
+	mustDeployContract := !*inputLoadTestParams.SkipContractDeploy
+	if mustDeployContract || anyModeRequiresLoadTestContract(ltp.ParsedModes) {
 		ltAddr, ltContract, err = getLoadTestContract(ctx, c, tops, cops)
 		if err != nil {
 			return err

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -937,9 +937,9 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 }
 
 func getLoadTestContract(ctx context.Context, c *ethclient.Client, tops *bind.TransactOpts, cops *bind.CallOpts) (ltAddr ethcommon.Address, ltContract *tester.LoadTester, err error) {
-	ltAddr = ethcommon.HexToAddress(*inputLoadTestParams.LtAddress)
+	ltAddr = ethcommon.HexToAddress(*inputLoadTestParams.LoadtestContractAddress)
 
-	if *inputLoadTestParams.LtAddress == "" {
+	if *inputLoadTestParams.LoadtestContractAddress == "" {
 		ltAddr, _, _, err = tester.DeployLoadTester(tops, c)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to create the load testing contract. Do you have the right chain id? Do you have enough funds?")
@@ -1293,7 +1293,7 @@ func loadTestStore(ctx context.Context, c *ethclient.Client, tops *bind.Transact
 
 	ltp := inputLoadTestParams
 
-	inputData := make([]byte, *ltp.ByteCount)
+	inputData := make([]byte, *ltp.StoreDataSize)
 	_, _ = hexwordRead(inputData)
 	t1 = time.Now()
 	defer func() { t2 = time.Now() }()

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -677,8 +677,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	// deploy and instantiate the load tester contract
 	var ltAddr ethcommon.Address
 	var ltContract *tester.LoadTester
-	mustDeployContract := !*inputLoadTestParams.SkipContractDeploy
-	if mustDeployContract || anyModeRequiresLoadTestContract(ltp.ParsedModes) {
+	if anyModeRequiresLoadTestContract(ltp.ParsedModes) {
 		ltAddr, ltContract, err = getLoadTestContract(ctx, c, tops, cops)
 		if err != nil {
 			return err

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -647,7 +647,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 	chainID := new(big.Int).SetUint64(*ltp.ChainID)
 	privateKey := ltp.ECDSAPrivateKey
 	mode := ltp.Mode
-	steadyStateTxPoolSize := *ltp.SteadyStateTxPoolSize
+	steadyStateTxPoolSize := *ltp.AdaptiveTargetSize
 	adaptiveRateLimitIncrement := *ltp.AdaptiveRateLimitIncrement
 	rl = rate.NewLimiter(rate.Limit(*ltp.RateLimit), 1)
 	if *ltp.RateLimit <= 0.0 {

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1037,7 +1037,7 @@ func loadTestTransaction(ctx context.Context, c *ethclient.Client, tops *bind.Tr
 	ltp := inputLoadTestParams
 
 	to := ltp.ToETHAddress
-	if *ltp.ToRandom {
+	if *ltp.RandomRecipients {
 		to = getRandomAddress()
 	}
 
@@ -1319,7 +1319,7 @@ func loadTestERC20(ctx context.Context, c *ethclient.Client, tops *bind.Transact
 	ltp := inputLoadTestParams
 
 	to := ltp.ToETHAddress
-	if *ltp.ToRandom {
+	if *ltp.RandomRecipients {
 		to = getRandomAddress()
 	}
 	amount := ltp.SendAmount
@@ -1350,7 +1350,7 @@ func loadTestERC721(ctx context.Context, c *ethclient.Client, tops *bind.Transac
 	ltp := inputLoadTestParams
 
 	to := ltp.ToETHAddress
-	if *ltp.ToRandom {
+	if *ltp.RandomRecipients {
 		to = getRandomAddress()
 	}
 
@@ -1699,7 +1699,7 @@ func loadTestBlob(ctx context.Context, c *ethclient.Client, tops *bind.TransactO
 	ltp := inputLoadTestParams
 
 	to := ltp.ToETHAddress
-	if *ltp.ToRandom {
+	if *ltp.RandomRecipients {
 		to = getRandomAddress()
 	}
 

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -1348,7 +1348,6 @@ func loadTestERC721(ctx context.Context, c *ethclient.Client, tops *bind.Transac
 	var tx *ethtypes.Transaction
 
 	ltp := inputLoadTestParams
-	iterations := ltp.Iterations
 
 	to := ltp.ToETHAddress
 	if *ltp.ToRandom {
@@ -1359,14 +1358,14 @@ func loadTestERC721(ctx context.Context, c *ethclient.Client, tops *bind.Transac
 	defer func() { t2 = time.Now() }()
 	if *ltp.EthCallOnly {
 		tops.NoSend = true
-		tx, err = erc721Contract.MintBatch(tops, *to, new(big.Int).SetUint64(*iterations))
+		tx, err = erc721Contract.MintBatch(tops, *to, big.NewInt(1))
 		if err != nil {
 			return
 		}
 		msg := txToCallMsg(tx)
 		_, err = c.CallContract(ctx, msg, nil)
 	} else {
-		tx, err = erc721Contract.MintBatch(tops, *to, new(big.Int).SetUint64(*iterations))
+		tx, err = erc721Contract.MintBatch(tops, *to, big.NewInt(1))
 		if err == nil && tx != nil {
 			txHash = tx.Hash()
 		}

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -418,9 +418,9 @@ func readPrivateKeysFromFile(sendingAddressesFile string) ([]*ecdsa.PrivateKey, 
 }
 
 func completeLoadTest(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) error {
-	if *inputLoadTestParams.SendOnly {
+	if *inputLoadTestParams.FireAndForget {
 		log.Info().
-			Msg("SendOnly mode enabled - skipping wait period and summarization")
+			Msg("FireAndForget mode enabled - skipping wait period and summarization")
 		return nil
 	}
 	log.Debug().
@@ -863,7 +863,7 @@ func mainLoop(ctx context.Context, c *ethclient.Client, rpc *ethrpc.Client) erro
 				default:
 					log.Error().Str("mode", mode.String()).Msg("We've arrived at a load test mode that we don't recognize")
 				}
-				if !*inputLoadTestParams.SendOnly {
+				if !*inputLoadTestParams.FireAndForget {
 					recordSample(routineID, requestID, tErr, startReq, endReq, sendingTops.Nonce.Uint64())
 				}
 				if tErr != nil {

--- a/cmd/loadtest/loadtestmode_string.go
+++ b/cmd/loadtest/loadtestmode_string.go
@@ -11,25 +11,21 @@ func _() {
 	_ = x[loadTestModeERC20-0]
 	_ = x[loadTestModeERC721-1]
 	_ = x[loadTestModeBlob-2]
-	_ = x[loadTestModeCall-3]
-	_ = x[loadTestModeContractCall-4]
-	_ = x[loadTestModeDeploy-5]
-	_ = x[loadTestModeFunction-6]
-	_ = x[loadTestModeInscription-7]
-	_ = x[loadTestModeIncrement-8]
-	_ = x[loadTestModeRandomPrecompiledContract-9]
-	_ = x[loadTestModeSpecificPrecompiledContract-10]
-	_ = x[loadTestModeRandom-11]
-	_ = x[loadTestModeRecall-12]
-	_ = x[loadTestModeRPC-13]
-	_ = x[loadTestModeStore-14]
-	_ = x[loadTestModeTransaction-15]
-	_ = x[loadTestModeUniswapV3-16]
+	_ = x[loadTestModeContractCall-3]
+	_ = x[loadTestModeDeploy-4]
+	_ = x[loadTestModeInscription-5]
+	_ = x[loadTestModeIncrement-6]
+	_ = x[loadTestModeRandom-7]
+	_ = x[loadTestModeRecall-8]
+	_ = x[loadTestModeRPC-9]
+	_ = x[loadTestModeStore-10]
+	_ = x[loadTestModeTransaction-11]
+	_ = x[loadTestModeUniswapV3-12]
 }
 
-const _loadTestMode_name = "loadTestModeERC20loadTestModeERC721loadTestModeBlobloadTestModeCallloadTestModeContractCallloadTestModeDeployloadTestModeFunctionloadTestModeInscriptionloadTestModeIncrementloadTestModeRandomPrecompiledContractloadTestModeSpecificPrecompiledContractloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeStoreloadTestModeTransactionloadTestModeUniswapV3"
+const _loadTestMode_name = "loadTestModeERC20loadTestModeERC721loadTestModeBlobloadTestModeContractCallloadTestModeDeployloadTestModeInscriptionloadTestModeIncrementloadTestModeRandomloadTestModeRecallloadTestModeRPCloadTestModeStoreloadTestModeTransactionloadTestModeUniswapV3"
 
-var _loadTestMode_index = [...]uint16{0, 17, 35, 51, 67, 91, 109, 129, 152, 173, 210, 249, 267, 285, 300, 317, 340, 361}
+var _loadTestMode_index = [...]uint8{0, 17, 35, 51, 75, 93, 116, 137, 155, 173, 188, 205, 228, 249}
 
 func (i loadTestMode) String() string {
 	if i < 0 || i >= loadTestMode(len(_loadTestMode_index)-1) {

--- a/cmd/monitorv2/renderer/tview_renderer.go
+++ b/cmd/monitorv2/renderer/tview_renderer.go
@@ -139,10 +139,10 @@ type TviewRenderer struct {
 	searchForm *tview.Form
 
 	// Modal state management
-	isModalActive      bool
-	activeModalName    string
-	previousPageName   string // Track page before modal was opened
-	modalStateMu       sync.RWMutex
+	isModalActive    bool
+	activeModalName  string
+	previousPageName string // Track page before modal was opened
+	modalStateMu     sync.RWMutex
 }
 
 // NewTviewRenderer creates a new TUI renderer using tview
@@ -778,7 +778,6 @@ func formatConnectionStatus(latency time.Duration) string {
 	}
 }
 
-
 // formatRelativeTime converts Unix timestamp to human-readable relative time
 func formatRelativeTime(timestamp uint64) string {
 	now := time.Now().Unix()
@@ -870,12 +869,12 @@ func formatBaseFee(baseFee *big.Int) string {
 	}
 
 	units := []unit{
-		{new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), "ether", new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), 3},  // 10^18
-		{new(big.Int).Exp(big.NewInt(10), big.NewInt(15), nil), "milli", new(big.Int).Exp(big.NewInt(10), big.NewInt(15), nil), 3},  // 10^15 milliether
-		{new(big.Int).Exp(big.NewInt(10), big.NewInt(12), nil), "micro", new(big.Int).Exp(big.NewInt(10), big.NewInt(12), nil), 3},  // 10^12 microether
-		{new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil), "gwei", new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil), 3},     // 10^9 gwei
-		{new(big.Int).Exp(big.NewInt(10), big.NewInt(6), nil), "mwei", new(big.Int).Exp(big.NewInt(10), big.NewInt(6), nil), 3},     // 10^6 megawei
-		{new(big.Int).Exp(big.NewInt(10), big.NewInt(3), nil), "kwei", new(big.Int).Exp(big.NewInt(10), big.NewInt(3), nil), 3},     // 10^3 kilowei
+		{new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), "ether", new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), 3}, // 10^18
+		{new(big.Int).Exp(big.NewInt(10), big.NewInt(15), nil), "milli", new(big.Int).Exp(big.NewInt(10), big.NewInt(15), nil), 3}, // 10^15 milliether
+		{new(big.Int).Exp(big.NewInt(10), big.NewInt(12), nil), "micro", new(big.Int).Exp(big.NewInt(10), big.NewInt(12), nil), 3}, // 10^12 microether
+		{new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil), "gwei", new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil), 3},    // 10^9 gwei
+		{new(big.Int).Exp(big.NewInt(10), big.NewInt(6), nil), "mwei", new(big.Int).Exp(big.NewInt(10), big.NewInt(6), nil), 3},    // 10^6 megawei
+		{new(big.Int).Exp(big.NewInt(10), big.NewInt(3), nil), "kwei", new(big.Int).Exp(big.NewInt(10), big.NewInt(3), nil), 3},    // 10^3 kilowei
 		{big.NewInt(1), "wei", big.NewInt(1), 0}, // wei (no decimals)
 	}
 
@@ -899,7 +898,7 @@ func formatBaseFee(baseFee *big.Int) string {
 			// Format with appropriate precision
 			formatStr := fmt.Sprintf("%%.%df %%s", u.decimals)
 			resultFloat, _ := result.Float64()
-			
+
 			// Remove trailing zeros from decimal representation
 			formatted := fmt.Sprintf(formatStr, resultFloat, u.name)
 			return removeTrailingZeros(formatted)
@@ -1393,7 +1392,7 @@ func (t *TviewRenderer) showSearchError(message string) {
 func (t *TviewRenderer) showModal(name string) {
 	// Get current page before showing modal
 	currentPage, _ := t.pages.GetFrontPage()
-	
+
 	t.modalStateMu.Lock()
 	t.isModalActive = true
 	t.activeModalName = name

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -104,6 +104,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --adaptive-cycle-duration-seconds uint   When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
       --adaptive-rate-limit                    Enable AIMD-style congestion control to automatically adjust request rate
       --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --adaptive-target-size uint              When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
       --address-funding-amount big.Int         The amount in wei to fund the sending addresses with. Set to 0 to disable account funding (useful for call-only mode or pre-funded addresses).
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
       --blob-fee-cap uint                      The blob fee cap, or the maximum blob fee per chunk, in Gwei. (default 100000)
@@ -158,7 +159,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --send-only                              Send transactions and load without waiting for it to be mined.
       --sending-address-count uint             The number of sending addresses to use. This is useful for avoiding pool account queue. (default 1)
       --sending-addresses-file string          The file containing the sending addresses private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending addresses for different execution cycles.
-      --steady-state-tx-pool-size uint         When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
       --store-data-size uint                   If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -108,7 +108,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --address-funding-amount big.Int         The amount in wei to fund the sending addresses with. Set to 0 to disable account funding (useful for call-only mode or pre-funded addresses).
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
       --blob-fee-cap uint                      The blob fee cap, or the maximum blob fee per chunk, in Gwei. (default 100000)
-      --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
       --calldata string                        The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address
       --chain-id uint                          The chain id for the transactions.
   -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
@@ -118,6 +117,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --erc721-address string                  The address of a pre-deployed ERC721 contract
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
       --eth-call-only                          When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
+      --eth-call-only-latest                   When using call only mode with recall, should we execute on the latest block or on the original block
       --fire-and-forget                        Send transactions and load without waiting for it to be mined.
       --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.
       --function-arg strings                   The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.
@@ -127,7 +127,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --gas-price-multiplier float             A multiplier to increase or decrease the gas price (default 1)
   -h, --help                                   help for loadtest
       --inscription-content string             The inscription content that will be encoded as calldata. This must be paired up with --mode inscription (default "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
-  -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
       --keep-funded-amount                     If set to true, the funded amount will be kept in the sending addresses. Otherwise, the funded amount will be refunded back to the account used to fund the account.
       --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
       --loadtest-contract-address string       The address of a pre-deployed load test contract
@@ -152,6 +151,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
       --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
       --proxy string                           Use the proxy specified
+      --random-recipients                      When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
       --rate-limit float                       An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
       --recall-blocks uint                     The number of blocks that we'll attempt to fetch for recall (default 50)
   -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
@@ -163,7 +163,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
       --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
-      --to-random                              When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
 ```
 
 The command also inherits flags from parent commands.

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -118,6 +118,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --erc20-address string                   The address of a pre-deployed ERC20 contract
       --erc721-address string                  The address of a pre-deployed ERC721 contract
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
+      --fire-and-forget                        Send transactions and load without waiting for it to be mined.
       --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.
       --function-arg strings                   The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.
       --function-signature string              The contract's function signature that will be called. The format is '<function name>(<types...>)'. This must be paired up with '--mode contract-call' and '--contract-address'. If the function requires parameters you can pass them with '--function-arg <value>'.
@@ -156,7 +157,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
   -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
   -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
       --seed int                               A seed for generating random values and addresses (default 123456)
-      --send-only                              Send transactions and load without waiting for it to be mined.
       --sending-address-count uint             The number of sending addresses to use. This is useful for avoiding pool account queue. (default 1)
       --sending-addresses-file string          The file containing the sending addresses private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending addresses for different execution cycles.
       --store-data-size uint                   If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -158,7 +158,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --seed int                               A seed for generating random values and addresses (default 123456)
       --sending-address-count uint             The number of sending addresses to use. This is useful for avoiding pool account queue. (default 1)
       --sending-addresses-file string          The file containing the sending addresses private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending addresses for different execution cycles.
-      --skip-contract-deploy                   Some load test modes don't require a contract deployment. Set this flag to true(default) to skip contract deployments. This will still respect the --loadtest-contract-address flags. (default true)
       --store-data-size uint                   If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -108,7 +108,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --address-funding-amount big.Int         The amount in wei to fund the sending addresses with. Set to 0 to disable account funding (useful for call-only mode or pre-funded addresses).
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
       --blob-fee-cap uint                      The blob fee cap, or the maximum blob fee per chunk, in Gwei. (default 100000)
-      --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
       --calldata string                        The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address
       --chain-id uint                          The chain id for the transactions.
@@ -118,6 +117,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --erc20-address string                   The address of a pre-deployed ERC20 contract
       --erc721-address string                  The address of a pre-deployed ERC721 contract
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
+      --eth-call-only                          When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --fire-and-forget                        Send transactions and load without waiting for it to be mined.
       --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.
       --function-arg strings                   The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -119,7 +119,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --eth-call-only                          When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --eth-call-only-latest                   When using call only mode with recall, should we execute on the latest block or on the original block
       --fire-and-forget                        Send transactions and load without waiting for it to be mined.
-      --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.
       --function-arg strings                   The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.
       --function-signature string              The contract's function signature that will be called. The format is '<function name>(<types...>)'. This must be paired up with '--mode contract-call' and '--contract-address'. If the function requires parameters you can pass them with '--function-arg <value>'.
       --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
@@ -127,7 +126,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --gas-price-multiplier float             A multiplier to increase or decrease the gas price (default 1)
   -h, --help                                   help for loadtest
       --inscription-content string             The inscription content that will be encoded as calldata. This must be paired up with --mode inscription (default "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
-      --keep-funded-amount                     If set to true, the funded amount will be kept in the sending addresses. Otherwise, the funded amount will be refunded back to the account used to fund the account.
+      --keep-funds-after-test                  If set to true, the funded amount will be kept in the sending addresses. Otherwise, the funded amount will be refunded back to the account used to fund the account.
       --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
       --loadtest-contract-address string       The address of a pre-deployed load test contract
   -m, --mode strings                           The testing mode to use. It can be multiple like: "c,d,f,t"
@@ -159,6 +158,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --seed int                               A seed for generating random values and addresses (default 123456)
       --sending-address-count uint             The number of sending addresses to use. This is useful for avoiding pool account queue. (default 1)
       --sending-addresses-file string          The file containing the sending addresses private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending addresses for different execution cycles.
+      --skip-contract-deploy                   Some load test modes don't require a contract deployment. Set this flag to true(default) to skip contract deployments. This will still respect the --loadtest-contract-address flags. (default true)
       --store-data-size uint                   If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -118,8 +118,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --erc20-address string                   The address of a pre-deployed ERC20 contract
       --erc721-address string                  The address of a pre-deployed ERC721 contract
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
-      --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --lt-address flags.
-  -f, --function uint                          A specific function to be called if running with --mode f or a specific precompiled contract when running with --mode a (default 1)
+      --force-contract-deploy                  Some load test modes don't require a contract deployment. Set this flag to true to force contract deployments. This will still respect the --loadtest-contract-address flags.
       --function-arg strings                   The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.
       --function-signature string              The contract's function signature that will be called. The format is '<function name>(<types...>)'. This must be paired up with '--mode contract-call' and '--contract-address'. If the function requires parameters you can pass them with '--function-arg <value>'.
       --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
@@ -130,7 +129,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
   -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
       --keep-funded-amount                     If set to true, the funded amount will be kept in the sending addresses. Otherwise, the funded amount will be refunded back to the account used to fund the account.
       --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
-      --lt-address string                      The address of a pre-deployed load test contract
+      --loadtest-contract-address string       The address of a pre-deployed load test contract
   -m, --mode strings                           The testing mode to use. It can be multiple like: "c,d,f,t"
                                                2, erc20 - Send ERC20 tokens
                                                7, erc721 - Mint ERC721 tokens
@@ -138,11 +137,8 @@ The codebase has a contract that used for load testing. It's written in Solidity
                                                c, call - Call random contract functions
                                                cc, contract-call - Make contract calls
                                                d, deploy - Deploy contracts
-                                               f, function - Call random contract functions
                                                i, inscription - Send inscription transactions
                                                inc, increment - Increment a counter
-                                               pr, random-precompile - Call random precompiled contracts
-                                               px, specific-precompile - Call specific precompiled contracts
                                                r, random - Random modes (does not include the following modes: blob, call, inscription, recall, rpc, uniswapv3)
                                                R, recall - Replay or simulate transactions
                                                rpc - Call random rpc methods

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -107,7 +107,6 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --address-funding-amount big.Int         The amount in wei to fund the sending addresses with. Set to 0 to disable account funding (useful for call-only mode or pre-funded addresses).
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
       --blob-fee-cap uint                      The blob fee cap, or the maximum blob fee per chunk, in Gwei. (default 100000)
-  -b, --byte-count uint                        If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
       --calldata string                        The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address
@@ -160,6 +159,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --sending-address-count uint             The number of sending addresses to use. This is useful for avoiding pool account queue. (default 1)
       --sending-addresses-file string          The file containing the sending addresses private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending addresses for different execution cycles.
       --steady-state-tx-pool-size uint         When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
+      --store-data-size uint                   If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
       --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -82,12 +82,12 @@ The command also inherits flags from parent commands.
       --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
       --adaptive-target-size uint              When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
-      --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
       --chain-id uint                          The chain id for the transactions.
   -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
       --config string                          config file (default is $HOME/.polygon-cli.yaml)
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
+      --eth-call-only                          When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --fire-and-forget                        Send transactions and load without waiting for it to be mined.
       --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
       --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -80,6 +80,7 @@ The command also inherits flags from parent commands.
       --adaptive-cycle-duration-seconds uint   When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
       --adaptive-rate-limit                    Enable AIMD-style congestion control to automatically adjust request rate
       --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
+      --adaptive-target-size uint              When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
       --call-only                              When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
       --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
@@ -102,7 +103,6 @@ The command also inherits flags from parent commands.
   -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
       --seed int                               A seed for generating random values and addresses (default 123456)
       --send-only                              Send transactions and load without waiting for it to be mined.
-      --steady-state-tx-pool-size uint         When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
       --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -88,6 +88,7 @@ The command also inherits flags from parent commands.
   -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
       --config string                          config file (default is $HOME/.polygon-cli.yaml)
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
+      --fire-and-forget                        Send transactions and load without waiting for it to be mined.
       --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
       --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually
       --gas-price-multiplier float             A multiplier to increase or decrease the gas price (default 1)
@@ -102,7 +103,6 @@ The command also inherits flags from parent commands.
   -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
   -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
       --seed int                               A seed for generating random values and addresses (default 123456)
-      --send-only                              Send transactions and load without waiting for it to be mined.
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
       --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -82,23 +82,23 @@ The command also inherits flags from parent commands.
       --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
       --adaptive-target-size uint              When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
       --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
-      --call-only-latest                       When using call only mode with recall, should we execute on the latest block or on the original block
       --chain-id uint                          The chain id for the transactions.
   -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
       --config string                          config file (default is $HOME/.polygon-cli.yaml)
       --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
       --eth-call-only                          When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
+      --eth-call-only-latest                   When using call only mode with recall, should we execute on the latest block or on the original block
       --fire-and-forget                        Send transactions and load without waiting for it to be mined.
       --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
       --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually
       --gas-price-multiplier float             A multiplier to increase or decrease the gas price (default 1)
-  -i, --iterations uint                        If we're making contract calls, this controls how many times the contract will execute the instruction in a loop. If we are making ERC721 Mints, this indicates the minting batch size (default 1)
       --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
       --nonce uint                             Use this flag to manually set the starting nonce
       --output-mode string                     Format mode for summary output (json | text) (default "text")
       --pretty-logs                            Should logs be in pretty format or JSON (default true)
       --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
       --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
+      --random-recipients                      When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
       --rate-limit float                       An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
   -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
   -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
@@ -106,7 +106,6 @@ The command also inherits flags from parent commands.
       --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
   -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
       --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
-      --to-random                              When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
   -v, --verbosity int                          0 - Silent
                                                100 Panic
                                                200 Fatal

--- a/rpctypes/pretty.go
+++ b/rpctypes/pretty.go
@@ -48,21 +48,21 @@ func (h *HexBytes) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &s); err != nil {
 		return err
 	}
-	
+
 	if s == "" || s == "0x" {
 		*h = HexBytes{}
 		return nil
 	}
-	
+
 	if !strings.HasPrefix(s, "0x") {
 		return fmt.Errorf("hex string must start with 0x")
 	}
-	
+
 	decoded, err := hex.DecodeString(s[2:])
 	if err != nil {
 		return err
 	}
-	
+
 	*h = HexBytes(decoded)
 	return nil
 }


### PR DESCRIPTION
closes https://github.com/0xPolygon/devtools/issues/355

# Description

## Remove modes: 
- `call`
- `function`
- `random-precompile`
- `specific-precompile`

## Flags renamed:
- `--lt-address to `--loadtest-contract-address`
- `-b, --byte-count` to `--store-data-size`
- `--steady-state-tx-pool-size` to --adaptive-target-size`
- `--send-only` to --fire-and-forget`
- `--call-only` to `--eth-call-only`
- `--to`-random to `--random-recipients`

## Flags removed:
- `-i, --iterations`
- `--force-contract-deploy`
 
## Features affected:
- If a mode requires an SC to work, the SC will be deployed automatically without requiring a flag to force it, or it will skip the deploy in case the address is provided via a flag. This applies to the modes: `Increment`, `Random`, `Store`, `ERC20`, and `ERC721`.
