### PR TITLE
feat: [loadtest] add --max-base-fee-gwei flag

### DIFF
--- a/cmd/loadtest/app.go
+++ b/cmd/loadtest/app.go
@@ -88,6 +88,7 @@ type (
 		WaitForReceipt                *bool
 		ReceiptRetryMax               *uint
 		ReceiptRetryInitialDelayMs    *uint
+		MaxBaseFeeGwei                *uint64
 
 		// Computed
 		CurrentGasPrice       *big.Int
@@ -251,6 +252,7 @@ func initFlags() {
 	ltp.PreFundSendingAccounts = LoadtestCmd.Flags().Bool("pre-fund-sending-accounts", false, "If set to true, the sending accounts will be funded at the start of the execution, otherwise all accounts will be funded when used for the first time.")
 	ltp.RefundRemainingFunds = LoadtestCmd.Flags().Bool("refund-remaining-funds", false, "If set to true, the funded amount will be refunded to the funding account. Otherwise, the funded amount will remain in the sending accounts.")
 	ltp.SendingAccountsFile = LoadtestCmd.Flags().String("sending-accounts-file", "", "The file containing the sending accounts private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending accounts for different execution cycles.")
+	ltp.MaxBaseFeeGwei = LoadtestCmd.Flags().Uint64("max-base-fee-gwei", 0, "The maximum base fee in gwei. If the base fee exceeds this value, sending tx will be paused and while paused, existing in-flight transactions continue to confirmation, but no additional SendTransaction calls occur. This is useful to avoid sending transactions when the network is congested.")
 
 	// Local flags.
 	ltp.Modes = LoadtestCmd.Flags().StringSliceP("mode", "m", []string{"t"}, `The testing mode to use. It can be multiple like: "d,t"

--- a/contracts/foundry.lock
+++ b/contracts/foundry.lock
@@ -1,8 +1,8 @@
 {
-  "lib/openzeppelin-contracts": {
-    "rev": "fd81a96f01cc42ef1c9a5399364968d0e07e9e90"
-  },
   "lib/forge-std": {
     "rev": "1d9650e951204a0ddce9ff89c32f1997984cef4d"
+  },
+  "lib/openzeppelin-contracts": {
+    "rev": "fd81a96f01cc42ef1c9a5399364968d0e07e9e90"
   }
 }

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -107,6 +107,7 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --inscription-content string             The inscription content that will be encoded as calldata. This must be paired up with --mode inscription (default "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
       --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
       --loadtest-contract-address string       The address of a pre-deployed load test contract
+      --max-base-fee-gwei uint                 The maximum base fee in gwei. If the base fee exceeds this value, sending tx will be paused and while paused, existing in-flight transactions continue to confirmation, but no additional SendTransaction calls occur. This is useful to avoid sending transactions when the network is congested.
   -m, --mode strings                           The testing mode to use. It can be multiple like: "d,t"
                                                2, erc20 - Send ERC20 tokens
                                                7, erc721 - Mint ERC721 tokens

--- a/docker/Dockerfile.gen-go-bindings
+++ b/docker/Dockerfile.gen-go-bindings
@@ -16,7 +16,7 @@ RUN abigen --version
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN . ~/.bashrc
 ENV PATH="/root/.foundry/bin:${PATH}"
-RUN ~/.foundry/bin/foundryup
+RUN ~/.foundry/bin/foundryup --install 1.3.2
 RUN ~/.foundry/bin/forge --version
 
 ## Install jq


### PR DESCRIPTION
closes [#353](https://github.com/0xPolygon/devtools/issues/353)

It adds a new flag, `--max-base-fee-gwei,` to allow testers to pause the test execution while the base fee exceeds the max base fee configured.