### PR TITLE
!feat: ulxly integration with agglayer bridge service

### DIFF
--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -340,7 +340,7 @@ func initializeAccountPool(ctx context.Context, c *ethclient.Client, privateKey 
 		if len(privateKeys) == 0 {
 			const errMsg = "no private keys found in sending accounts file"
 			log.Error().Str("sendingAccountsFile", sendingAccountsFile).Msg(errMsg)
-			return fmt.Errorf(errMsg)
+			return errors.New(errMsg)
 		}
 
 		if len(privateKeys) > 1 && *inputLoadTestParams.StartNonce > 0 {

--- a/cmd/ulxly/bridge_service/agglayer/deposit.go
+++ b/cmd/ulxly/bridge_service/agglayer/deposit.go
@@ -1,0 +1,72 @@
+package agglayer
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type GetBridgeResponse struct {
+	Bridges []BridgeResponse `json:"bridges"`
+	Count   int              `json:"count"`
+}
+
+type BridgeResponse struct {
+	LeafType uint8 `json:"leaf_type"`
+
+	OrigNet    uint32 `json:"origin_network"`
+	OrigAddr   string `json:"origin_address"`
+	Amount     string `json:"amount"`
+	DestNet    uint32 `json:"destination_network"`
+	DestAddr   string `json:"destination_address"`
+	BlockNum   uint64 `json:"block_num"`
+	DepositCnt uint32 `json:"deposit_count"`
+	NetworkID  uint32 `json:"network_id"`
+	TxHash     string `json:"tx_hash"`
+	Metadata   string `json:"metadata"`
+
+	// Additional fields from the AggLayer API
+	BridgeHash     string `json:"bridge_hash"`
+	BlockPos       uint64 `json:"block_pos"`
+	BlockTimestamp uint64 `json:"block_timestamp"`
+	Calldata       string `json:"calldata"`
+	FromAddress    string `json:"from_address"`
+
+	// TODO: REVIEW THESE INFORMATION USED IN THE LEGACY BRIDGE SERVICE
+	// ClaimTxHash   string `json:"claim_tx_hash"`
+	// ReadyForClaim bool   `json:"ready_for_claim"`
+	// GlobalIndex   string `json:"global_index"`
+}
+
+func (r *BridgeResponse) ToDeposit() *bridge_service.Deposit {
+	d := &bridge_service.Deposit{}
+	d.BlockNum = r.BlockNum
+
+	d.GlobalIndex = new(big.Int)
+	// d.GlobalIndex.SetString(r.GlobalIndex, 10)
+
+	d.Amount = new(big.Int)
+	d.Amount.SetString(r.Amount, 10)
+
+	d.TxHash = common.HexToHash(r.TxHash)
+	// if len(r.ClaimTxHash) > 0 {
+	// 	claimTxHash := common.HexToHash(r.ClaimTxHash)
+	// 	d.ClaimTxHash = &claimTxHash
+	// }
+
+	d.OrigAddr = common.HexToAddress(r.OrigAddr)
+	d.DestAddr = common.HexToAddress(r.DestAddr)
+
+	d.Metadata = common.Hex2Bytes(strings.TrimPrefix(r.Metadata, "0x"))
+
+	d.LeafType = r.LeafType
+	d.OrigNet = r.OrigNet
+	d.DestNet = r.DestNet
+	d.NetworkID = r.NetworkID
+	d.DepositCnt = r.DepositCnt
+	// d.ReadyForClaim = r.ReadyForClaim
+
+	return d
+}

--- a/cmd/ulxly/bridge_service/agglayer/error.go
+++ b/cmd/ulxly/bridge_service/agglayer/error.go
@@ -1,0 +1,5 @@
+package agglayer
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/cmd/ulxly/bridge_service/agglayer/interfaces.go
+++ b/cmd/ulxly/bridge_service/agglayer/interfaces.go
@@ -1,1 +1,0 @@
-package agglayer

--- a/cmd/ulxly/bridge_service/agglayer/interfaces.go
+++ b/cmd/ulxly/bridge_service/agglayer/interfaces.go
@@ -1,0 +1,1 @@
+package agglayer

--- a/cmd/ulxly/bridge_service/agglayer/proof.go
+++ b/cmd/ulxly/bridge_service/agglayer/proof.go
@@ -1,0 +1,52 @@
+package agglayer
+
+import (
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type GetClaimProofResponse struct {
+	L1InfoTreeLeafResponse L1InfoTreeLeafResponse `json:"l1_info_tree_leaf"`
+	ProofLocalExitRoot     []string               `json:"proof_local_exit_root"`
+	ProofRollupExitRoot    []string               `json:"proof_rollup_exit_root"`
+}
+
+type L1InfoTreeLeafResponse struct {
+	BlockNum          uint64 `json:"block_num"`
+	BlockPos          uint64 `json:"block_pos"`
+	GlobalExitRoot    string `json:"global_exit_root"`
+	Hash              string `json:"hash"`
+	L1InfoTreeIndex   uint64 `json:"l1_info_tree_index"`
+	MainnetExitRoot   string `json:"mainnet_exit_root"`
+	PreviousBlockHash string `json:"previous_block_hash"`
+	RollupExitRoot    string `json:"rollup_exit_root"`
+	Timestamp         uint64 `json:"timestamp"`
+}
+
+func (r *GetClaimProofResponse) ToProof() *bridge_service.Proof {
+	p := &bridge_service.Proof{}
+
+	var merkleProof = make([]common.Hash, len(r.ProofLocalExitRoot))
+	for i, p := range r.ProofLocalExitRoot {
+		merkleProof[i] = common.HexToHash(p)
+	}
+	p.MerkleProof = merkleProof
+
+	var rollupMerkleProof = make([]common.Hash, len(r.ProofRollupExitRoot))
+	for i, p := range r.ProofRollupExitRoot {
+		rollupMerkleProof[i] = common.HexToHash(p)
+	}
+	p.RollupMerkleProof = rollupMerkleProof
+
+	if len(r.L1InfoTreeLeafResponse.MainnetExitRoot) > 0 {
+		mainExitRoot := common.HexToHash(r.L1InfoTreeLeafResponse.MainnetExitRoot)
+		p.MainExitRoot = &mainExitRoot
+	}
+
+	if len(r.L1InfoTreeLeafResponse.RollupExitRoot) > 0 {
+		rollupExitRoot := common.HexToHash(r.L1InfoTreeLeafResponse.RollupExitRoot)
+		p.RollupExitRoot = &rollupExitRoot
+	}
+
+	return p
+}

--- a/cmd/ulxly/bridge_service/agglayer/service.go
+++ b/cmd/ulxly/bridge_service/agglayer/service.go
@@ -1,24 +1,128 @@
 package agglayer
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service/httpjson"
+	"github.com/rs/zerolog/log"
 )
 
 type BridgeService struct {
 	bridge_service.BridgeServiceBase
+	httpClient *http.Client
 }
 
 // NewBridgeService creates an instance of the BridgeService.
 func NewBridgeService(url string, insecure bool) (*BridgeService, error) {
-	return &BridgeService{}, nil
+	return &BridgeService{
+		httpClient:        httpjson.NewHTTPClient(insecure),
+		BridgeServiceBase: bridge_service.NewBridgeServiceBase(url),
+	}, nil
 }
 
 func (s *BridgeService) GetDeposit(depositNetwork, depositCount uint32) (*bridge_service.Deposit, error) {
-	panic("not implemented") // TODO: Implement
+	endpoint := fmt.Sprintf("%s/bridges?network_id=%d&deposit_count=%d", s.BridgeServiceBase.Url(), depositNetwork, depositCount)
+	resp, respError, statusCode, err := httpjson.HTTPGetWithError[GetBridgeResponse, ErrorResponse](s.httpClient, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		errMsg := "unable to retrieve bridge deposit"
+		log.Warn().Int("code", statusCode).Str("message", respError.Error).Msgf("%s", errMsg)
+		return nil, bridge_service.ErrUnableToRetrieveDeposit
+	}
+
+	deposit := resp.Bridges[0].ToDeposit()
+
+	return deposit, nil
 }
+
 func (s *BridgeService) GetDeposits(destinationAddress string, offset, limit int) ([]bridge_service.Deposit, int, error) {
-	panic("not implemented") // TODO: Implement
+	pageSize := limit
+	pageNumber := offset/limit + 1
+	skipItems := offset % limit
+
+	const endpointTemplate = "%s/bridges?from_address%s&page_number=%d&page_size=%d"
+
+	// loads all deposits when offset is exactly the size of a page or the first part of them when offset is not
+	// exactly the size of a page
+	endpoint := fmt.Sprintf(endpointTemplate, s.BridgeServiceBase.Url(), destinationAddress, pageSize, pageNumber)
+	resp, respError, statusCode, err := httpjson.HTTPGetWithError[GetBridgeResponse, ErrorResponse](s.httpClient, endpoint)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if statusCode != http.StatusOK {
+		errMsg := "unable to retrieve bridge deposits"
+		log.Warn().Int("code", statusCode).Str("message", respError.Error).Msgf("%s", errMsg)
+		return nil, 0, bridge_service.ErrUnableToRetrieveDeposit
+	}
+
+	bridgesResponses := make([]BridgeResponse, 0, limit)
+	bridgesResponses = append(bridgesResponses, resp.Bridges[skipItems:pageSize]...)
+
+	// loads the remaining part of deposits when offset is not exactly the size of a page
+	// this is needed because the API only supports pagination by page number and page size
+	// and not by offset and limit
+	if skipItems > 0 {
+		endpoint := fmt.Sprintf(endpointTemplate, s.BridgeServiceBase.Url(), destinationAddress, pageSize, pageNumber+1)
+		resp, respError, statusCode, err = httpjson.HTTPGetWithError[GetBridgeResponse, ErrorResponse](s.httpClient, endpoint)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if statusCode != http.StatusOK {
+			errMsg := "unable to retrieve bridge deposits"
+			log.Warn().Int("code", statusCode).Str("message", respError.Error).Msgf("%s", errMsg)
+			return nil, 0, bridge_service.ErrUnableToRetrieveDeposit
+		}
+
+		end := skipItems
+		if end > len(resp.Bridges) {
+			end = len(resp.Bridges)
+		}
+
+		bridgesResponses = append(bridgesResponses, resp.Bridges[0:end]...)
+	}
+
+	deposits := make([]bridge_service.Deposit, 0, len(bridgesResponses))
+	for _, d := range bridgesResponses {
+		deposit := d.ToDeposit()
+		deposits = append(deposits, *deposit)
+	}
+
+	return deposits, resp.Count, nil
+
 }
+
 func (s *BridgeService) GetProof(depositNetwork, depositCount uint32) (*bridge_service.Proof, error) {
-	panic("not implemented") // TODO: Implement
+	l1InfoTreeIndexEndpoint := fmt.Sprintf("%s/l1-info-tree-index?network_id=%d&deposit_count=%d", s.BridgeServiceBase.Url(), depositNetwork, depositCount)
+	l1InfoTreeIndex, l1InfoTreeIndexRespError, statusCode, err := httpjson.HTTPGetWithError[int, ErrorResponse](s.httpClient, l1InfoTreeIndexEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		errMsg := "unable to retrieve l1 info tree index"
+		log.Warn().Int("code", statusCode).Str("message", l1InfoTreeIndexRespError.Error).Msgf("%s", errMsg)
+		return nil, fmt.Errorf(l1InfoTreeIndexRespError.Error)
+	}
+
+	endpoint := fmt.Sprintf("%s/claim-proof?network_id=%d&leaf_index=%d&deposit_count=%d", s.BridgeServiceBase.Url(), depositNetwork, l1InfoTreeIndex, depositCount)
+	resp, respError, statusCode, err := httpjson.HTTPGetWithError[GetClaimProofResponse, ErrorResponse](s.httpClient, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		errMsg := "unable to retrieve bridge deposits"
+		log.Warn().Int("code", statusCode).Str("message", respError.Error).Msgf("%s", errMsg)
+		return nil, fmt.Errorf(respError.Error)
+	}
+
+	proof := resp.ToProof()
+	return proof, nil
 }

--- a/cmd/ulxly/bridge_service/agglayer/service.go
+++ b/cmd/ulxly/bridge_service/agglayer/service.go
@@ -1,0 +1,24 @@
+package agglayer
+
+import (
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+)
+
+type BridgeService struct {
+	bridge_service.BridgeServiceBase
+}
+
+// NewBridgeService creates an instance of the BridgeService.
+func NewBridgeService(url string, insecure bool) (*BridgeService, error) {
+	return &BridgeService{}, nil
+}
+
+func (s *BridgeService) GetDeposit(depositNetwork, depositCount uint32) (*bridge_service.Deposit, error) {
+	panic("not implemented") // TODO: Implement
+}
+func (s *BridgeService) GetDeposits(destinationAddress string, offset, limit int) ([]bridge_service.Deposit, int, error) {
+	panic("not implemented") // TODO: Implement
+}
+func (s *BridgeService) GetProof(depositNetwork, depositCount uint32) (*bridge_service.Proof, error) {
+	panic("not implemented") // TODO: Implement
+}

--- a/cmd/ulxly/bridge_service/agglayer/service_test.go
+++ b/cmd/ulxly/bridge_service/agglayer/service_test.go
@@ -1,0 +1,63 @@
+package agglayer
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestOffsetLimitToPagination(t *testing.T) {
+	arr := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	fmt.Println(OffsetLimitToPagination(arr, 5, 4))
+	fmt.Println(OffsetLimitToPagination(arr, 1, 7))
+	fmt.Println(OffsetLimitToPagination(arr, 8, 2))
+	fmt.Println(OffsetLimitToPagination(arr, 5, 5))
+	fmt.Println(OffsetLimitToPagination(arr, 10, 10))
+	fmt.Println(OffsetLimitToPagination(arr, 100, 100))
+	fmt.Println(OffsetLimitToPagination([]int{}, 100, 100))
+}
+
+func OffsetLimitToPagination(arr []int, offset, limit int) []int {
+	pageSize := limit
+	pageNumber := offset / limit
+	skipItems := offset % limit
+
+	totalPages := len(arr) / pageSize
+	if len(arr)%pageSize > 0 {
+		totalPages++
+	}
+
+	pages := make([][]int, totalPages)
+
+	if pageNumber >= totalPages {
+		return []int{}
+	}
+	items := []int{}
+
+	for i := 0; i < totalPages; i++ {
+		start := pageSize * i
+		end := pageSize * (i + 1)
+		if end > len(arr)-1 {
+			end = len(arr)
+		}
+		pages[i] = arr[start:end]
+	}
+
+	start := skipItems
+	end := pageSize
+	page := pages[pageNumber]
+	items = append(items, page[start:end]...)
+
+	if skipItems > 0 && pageNumber+1 < totalPages {
+		start := 0
+		end := skipItems
+		page := pages[pageNumber+1]
+		pageItensCount := len(page)
+		if pageItensCount < end {
+			end = pageItensCount
+		}
+
+		items = append(items, page[start:end]...)
+	}
+
+	return items
+}

--- a/cmd/ulxly/bridge_service/factory/factory.go
+++ b/cmd/ulxly/bridge_service/factory/factory.go
@@ -1,0 +1,14 @@
+package bridge_service_factory
+
+import (
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service/agglayer"
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service/legacy"
+)
+
+func NewBridgeService(url string, insecure, useLegacy bool) (bridge_service.BridgeService, error) {
+	if useLegacy {
+		return legacy.NewBridgeService(url, insecure)
+	}
+	return agglayer.NewBridgeService(url, insecure)
+}

--- a/cmd/ulxly/bridge_service/httpjson/httpjson.go
+++ b/cmd/ulxly/bridge_service/httpjson/httpjson.go
@@ -1,0 +1,49 @@
+package httpjson
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Helper function to get the appropriate HTTP client
+func NewHTTPClient(insecure bool) *http.Client {
+	if insecure {
+		log.Warn().Msg("WARNING: Using insecure HTTP client for bridge service requests")
+		return &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
+	}
+	return &http.Client{
+		Timeout: 30 * time.Second,
+	}
+}
+
+// Get makes an HTTP GET request to the specified URL and unmarshals the JSON response into the provided generic type T.
+func HTTPGet[T any](client *http.Client, url string) (T, error) {
+	var obj T
+	res, err := client.Get(url)
+	if err != nil {
+		return obj, err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return obj, err
+	}
+	defer res.Body.Close()
+
+	err = json.Unmarshal(body, &obj)
+	if err != nil {
+		return obj, err
+	}
+
+	return obj, nil
+}

--- a/cmd/ulxly/bridge_service/interface.go
+++ b/cmd/ulxly/bridge_service/interface.go
@@ -1,0 +1,68 @@
+package bridge_service
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	ErrUnableToRetrieveDeposit = errors.New("the bridge deposit was not found")
+)
+
+type BridgeService interface {
+	GetDeposit(depositNetwork, depositCount uint32) (*Deposit, error)
+	GetDeposits(destinationAddress string, offset, limit int) (deposits []Deposit, total int, err error)
+	GetProof(depositNetwork, depositCount uint32) (*Proof, error)
+	Url() string
+}
+
+type BridgeServiceBase struct {
+	url string
+}
+
+func (b *BridgeServiceBase) Url() string {
+	return b.url
+}
+
+func NewBridgeServiceBase(url string) BridgeServiceBase {
+	return BridgeServiceBase{
+		url: url,
+	}
+}
+
+type Deposit struct {
+	LeafType      uint8
+	OrigNet       uint32
+	OrigAddr      common.Address
+	Amount        *big.Int
+	DestNet       uint32
+	DestAddr      common.Address
+	BlockNum      uint64
+	DepositCnt    uint32
+	NetworkID     uint32
+	TxHash        common.Hash
+	ClaimTxHash   *common.Hash
+	Metadata      []byte
+	ReadyForClaim bool
+	GlobalIndex   *big.Int
+}
+
+type Proof struct {
+	MerkleProof       []common.Hash
+	RollupMerkleProof []common.Hash
+	MainExitRoot      *common.Hash
+	RollupExitRoot    *common.Hash
+}
+
+func HashArrayToBytesArray(hashes []common.Hash) [32][32]byte {
+	var array [32][32]byte
+	for i, h := range hashes {
+		if i >= 32 {
+			break
+		}
+		array[i] = h
+	}
+	return array
+}

--- a/cmd/ulxly/bridge_service/legacy/deposit.go
+++ b/cmd/ulxly/bridge_service/legacy/deposit.go
@@ -1,0 +1,73 @@
+package legacy
+
+import (
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type GetDepositResponse struct {
+	Deposit DepositResponse `json:"deposit"`
+	Code    *int            `json:"code"`
+	Message *string         `json:"message"`
+}
+
+type DepositResponse struct {
+	LeafType      uint8  `json:"leaf_type"`
+	OrigNet       uint32 `json:"orig_net"`
+	OrigAddr      string `json:"orig_addr"`
+	Amount        string `json:"amount"`
+	DestNet       uint32 `json:"dest_net"`
+	DestAddr      string `json:"dest_addr"`
+	BlockNum      string `json:"block_num"`
+	DepositCnt    uint32 `json:"deposit_cnt"`
+	NetworkID     uint32 `json:"network_id"`
+	TxHash        string `json:"tx_hash"`
+	ClaimTxHash   string `json:"claim_tx_hash"`
+	Metadata      string `json:"metadata"`
+	ReadyForClaim bool   `json:"ready_for_claim"`
+	GlobalIndex   string `json:"global_index"`
+}
+
+func (r *DepositResponse) ToDeposit() (*bridge_service.Deposit, error) {
+	d := &bridge_service.Deposit{}
+	var err error
+	d.BlockNum, err = strconv.ParseUint(r.BlockNum, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	d.GlobalIndex = new(big.Int)
+	d.GlobalIndex.SetString(r.GlobalIndex, 10)
+
+	d.Amount = new(big.Int)
+	d.Amount.SetString(r.Amount, 10)
+
+	d.TxHash = common.HexToHash(r.TxHash)
+	if len(r.ClaimTxHash) > 0 {
+		claimTxHash := common.HexToHash(r.ClaimTxHash)
+		d.ClaimTxHash = &claimTxHash
+	}
+
+	d.OrigAddr = common.HexToAddress(r.OrigAddr)
+	d.DestAddr = common.HexToAddress(r.DestAddr)
+
+	d.Metadata = common.Hex2Bytes(strings.TrimPrefix(r.Metadata, "0x"))
+
+	d.LeafType = r.LeafType
+	d.OrigNet = r.OrigNet
+	d.DestNet = r.DestNet
+	d.NetworkID = r.NetworkID
+	d.DepositCnt = r.DepositCnt
+	d.ReadyForClaim = r.ReadyForClaim
+
+	return d, nil
+}
+
+type GetDepositsResponse struct {
+	Deposits []DepositResponse `json:"deposit"`
+	Total    int               `json:"total_cnt,string"`
+}

--- a/cmd/ulxly/bridge_service/legacy/proof.go
+++ b/cmd/ulxly/bridge_service/legacy/proof.go
@@ -1,0 +1,46 @@
+package legacy
+
+import (
+	"github.com/0xPolygon/polygon-cli/cmd/ulxly/bridge_service"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type GetProofResponse struct {
+	Proof ProofResponse `json:"proof"`
+}
+
+type ProofResponse struct {
+	MerkleProof       []string `json:"merkle_proof"`
+	RollupMerkleProof []string `json:"rollup_merkle_proof"`
+	MainExitRoot      string   `json:"main_exit_root"`
+	RollupExitRoot    string   `json:"rollup_exit_root"`
+}
+
+func (r *ProofResponse) ToProof() *bridge_service.Proof {
+	p := &bridge_service.Proof{}
+
+	var merkleProof = make([]common.Hash, len(r.MerkleProof))
+	for i, p := range r.MerkleProof {
+		merkleProof[i] = common.HexToHash(p)
+	}
+
+	var rollupMerkleProof = make([]common.Hash, len(r.RollupMerkleProof))
+	for i, p := range r.RollupMerkleProof {
+		rollupMerkleProof[i] = common.HexToHash(p)
+	}
+
+	if len(r.MainExitRoot) > 0 {
+		mainExitRoot := common.HexToHash(r.MainExitRoot)
+		p.MainExitRoot = &mainExitRoot
+	}
+
+	if len(r.RollupExitRoot) > 0 {
+		rollupExitRoot := common.HexToHash(r.RollupExitRoot)
+		p.RollupExitRoot = &rollupExitRoot
+	}
+
+	p.MerkleProof = merkleProof
+	p.RollupMerkleProof = rollupMerkleProof
+
+	return p
+}

--- a/cmd/ulxly/bridge_service/legacy/proof.go
+++ b/cmd/ulxly/bridge_service/legacy/proof.go
@@ -23,11 +23,13 @@ func (r *ProofResponse) ToProof() *bridge_service.Proof {
 	for i, p := range r.MerkleProof {
 		merkleProof[i] = common.HexToHash(p)
 	}
+	p.MerkleProof = merkleProof
 
 	var rollupMerkleProof = make([]common.Hash, len(r.RollupMerkleProof))
 	for i, p := range r.RollupMerkleProof {
 		rollupMerkleProof[i] = common.HexToHash(p)
 	}
+	p.RollupMerkleProof = rollupMerkleProof
 
 	if len(r.MainExitRoot) > 0 {
 		mainExitRoot := common.HexToHash(r.MainExitRoot)
@@ -38,9 +40,6 @@ func (r *ProofResponse) ToProof() *bridge_service.Proof {
 		rollupExitRoot := common.HexToHash(r.RollupExitRoot)
 		p.RollupExitRoot = &rollupExitRoot
 	}
-
-	p.MerkleProof = merkleProof
-	p.RollupMerkleProof = rollupMerkleProof
 
 	return p
 }

--- a/cmd/ulxly/bridge_service/legacy/service.go
+++ b/cmd/ulxly/bridge_service/legacy/service.go
@@ -24,18 +24,18 @@ func NewBridgeService(url string, insecure bool) (*BridgeService, error) {
 
 func (s *BridgeService) GetDeposit(depositNetwork, depositCount uint32) (*bridge_service.Deposit, error) {
 	endpoint := fmt.Sprintf("%s/bridge?net_id=%d&deposit_cnt=%d", s.BridgeServiceBase.Url(), depositNetwork, depositCount)
-	depositResponse, err := httpjson.HTTPGet[GetDepositResponse](s.httpClient, endpoint)
+	resp, _, err := httpjson.HTTPGet[GetDepositResponse](s.httpClient, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	if depositResponse.Code != nil {
+	if resp.Code != nil {
 		errMsg := "unable to retrieve bridge deposit"
-		log.Warn().Int("code", *depositResponse.Code).Str("message", *depositResponse.Message).Msgf("%s", errMsg)
+		log.Warn().Int("code", *resp.Code).Str("message", *resp.Message).Msgf("%s", errMsg)
 		return nil, bridge_service.ErrUnableToRetrieveDeposit
 	}
 
-	deposit, err := depositResponse.Deposit.ToDeposit()
+	deposit, err := resp.Deposit.ToDeposit()
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (s *BridgeService) GetDeposit(depositNetwork, depositCount uint32) (*bridge
 
 func (s *BridgeService) GetDeposits(destinationAddress string, offset, limit int) ([]bridge_service.Deposit, int, error) {
 	url := fmt.Sprintf("%s/bridges/%s?offset=%d&limit=%d", s.BridgeServiceBase.Url(), destinationAddress, offset, limit)
-	resp, err := httpjson.HTTPGet[GetDepositsResponse](s.httpClient, url)
+	resp, _, err := httpjson.HTTPGet[GetDepositsResponse](s.httpClient, url)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -63,11 +63,11 @@ func (s *BridgeService) GetDeposits(destinationAddress string, offset, limit int
 
 func (s *BridgeService) GetProof(depositNetwork, depositCount uint32) (*bridge_service.Proof, error) {
 	endpoint := fmt.Sprintf("%s/merkle-proof?net_id=%d&deposit_cnt=%d", s.BridgeServiceBase.Url(), depositNetwork, depositCount)
-	proofResponse, err := httpjson.HTTPGet[GetProofResponse](s.httpClient, endpoint)
+	resp, _, err := httpjson.HTTPGet[GetProofResponse](s.httpClient, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	proof := proofResponse.Proof.ToProof()
+	proof := resp.Proof.ToProof()
 	return proof, nil
 }


### PR DESCRIPTION
closes https://github.com/0xPolygon/devtools/issues/351

It makes ulxly command compatible with multiple bridge service implementations and currently has the legacy and agglayer implementations in place.

`Breaking change:` A new boolean `--legacy` flag was added to the `ulxly` command to specify whether to use the legacy or not. The default value is `false` and forces the agglayer bridge service usage.

