### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/cmd/hash/hash.go
+++ b/cmd/hash/hash.go
@@ -8,6 +8,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -85,10 +86,8 @@ var HashCmd = &cobra.Command{
 		if len(args) < 1 {
 			return fmt.Errorf("expected 1 argument to specify hash function. got %d", len(args))
 		}
-		for _, v := range supportedHashFunctions {
-			if v == args[0] {
-				return nil
-			}
+		if slices.Contains(supportedHashFunctions, args[0]) {
+			return nil
 		}
 
 		return fmt.Errorf("the name %s is not recognized. Please use one of the following: %s", args[0], strings.Join(supportedHashFunctions, ","))

--- a/cmd/loadtest/loadtest.go
+++ b/cmd/loadtest/loadtest.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"os"
 	"os/signal"
@@ -132,20 +133,10 @@ func modeRequiresLoadTestContract(m loadTestMode) bool {
 	return false
 }
 func anyModeRequiresLoadTestContract(modes []loadTestMode) bool {
-	for _, m := range modes {
-		if modeRequiresLoadTestContract(m) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(modes, modeRequiresLoadTestContract)
 }
 func hasMode(mode loadTestMode, modes []loadTestMode) bool {
-	for _, m := range modes {
-		if m == mode {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(modes, mode)
 }
 
 func hasUniqueModes(modes []loadTestMode) bool {


### PR DESCRIPTION
# Description

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


## Jira / Linear Tickets

- [DVT-000]()

# Testing

<!-- Please describe the tests you ran to verify your changes. Provide
instructions so the tests are reproducible. Please also list any relevant
details for the test configuration -->

- [ ] Test A
- [ ] Test B
