### PR TITLE
feat(ulxly): add --proof-l1-info-tree-index flag for claim asset and message

### DIFF
--- a/cmd/ulxly/bridge_service/interface.go
+++ b/cmd/ulxly/bridge_service/interface.go
@@ -15,7 +15,9 @@ var (
 type BridgeService interface {
 	GetDeposit(depositNetwork, depositCount uint32) (*Deposit, error)
 	GetDeposits(destinationAddress string, offset, limit int) (deposits []Deposit, total int, err error)
-	GetProof(depositNetwork, depositCount uint32, ger *common.Hash) (*Proof, error)
+	GetProof(depositNetwork, depositCount uint32) (*Proof, error)
+	GetProofByGer(depositNetwork, depositCount uint32, ger common.Hash) (*Proof, error)
+	GetProofByL1InfoTreeIndex(depositNetwork, depositCount uint32, l1InfoTreeIndex uint32) (*Proof, error)
 	Url() string
 }
 

--- a/cmd/ulxly/bridge_service/legacy/service.go
+++ b/cmd/ulxly/bridge_service/legacy/service.go
@@ -66,11 +66,8 @@ func (s *BridgeService) GetDeposits(destinationAddress string, offset, limit int
 
 }
 
-func (s *BridgeService) GetProof(depositNetwork, depositCount uint32, ger *common.Hash) (*bridge_service.Proof, error) {
+func (s *BridgeService) GetProof(depositNetwork, depositCount uint32) (*bridge_service.Proof, error) {
 	endpoint := fmt.Sprintf("%s/merkle-proof?net_id=%d&deposit_cnt=%d", s.BridgeServiceBase.Url(), depositNetwork, depositCount)
-	if ger != nil {
-		endpoint = fmt.Sprintf("%s/merkle-proof-by-ger?net_id=%d&deposit_cnt=%d&ger=%s", s.BridgeServiceBase.Url(), depositNetwork, depositCount, ger.String())
-	}
 
 	resp, _, err := httpjson.HTTPGet[GetProofResponse](s.httpClient, endpoint)
 	if err != nil {
@@ -79,4 +76,20 @@ func (s *BridgeService) GetProof(depositNetwork, depositCount uint32, ger *commo
 
 	proof := resp.Proof.ToProof()
 	return proof, nil
+}
+
+func (s *BridgeService) GetProofByGer(depositNetwork, depositCount uint32, ger common.Hash) (*bridge_service.Proof, error) {
+	endpoint := fmt.Sprintf("%s/merkle-proof-by-ger?net_id=%d&deposit_cnt=%d&ger=%s", s.BridgeServiceBase.Url(), depositNetwork, depositCount, ger.String())
+
+	resp, _, err := httpjson.HTTPGet[GetProofResponse](s.httpClient, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	proof := resp.Proof.ToProof()
+	return proof, nil
+}
+
+func (s *BridgeService) GetProofByL1InfoTreeIndex(depositNetwork, depositCount uint32, l1InfoTreeIndex uint32) (*bridge_service.Proof, error) {
+	return nil, fmt.Errorf("GetProofByL1InfoTreeIndex is not supported in the legacy bridge service")
 }

--- a/doc/polycli_ulxly_claim.md
+++ b/doc/polycli_ulxly_claim.md
@@ -16,13 +16,14 @@ Commands for claiming deposits on a particular chain.
 ## Flags
 
 ```bash
-      --bridge-service-url string   URL of the bridge service
-      --deposit-count uint32        deposit count of the bridge transaction
-      --deposit-network uint32      rollup ID of the network where the deposit was made
-      --global-index string         an override of the global index value
-  -h, --help                        help for claim
-      --proof-ger string            if specified and using legacy mode, the proof will be generated against this GER
-      --wait duration               retry claiming until deposit is ready, up to specified duration (available for claim asset and claim message)
+      --bridge-service-url string         URL of the bridge service
+      --deposit-count uint32              deposit count of the bridge transaction
+      --deposit-network uint32            rollup ID of the network where the deposit was made
+      --global-index string               an override of the global index value
+  -h, --help                              help for claim
+      --proof-ger string                  if specified and using legacy mode, the proof will be generated against this GER
+      --proof-l1-info-tree-index uint32   if specified and using aggkit mode, the proof will be generated against this L1 Info Tree Index
+      --wait duration                     retry claiming until deposit is ready, up to specified duration (available for claim asset and claim message)
 ```
 
 The command also inherits flags from parent commands.

--- a/doc/polycli_ulxly_claim_asset.md
+++ b/doc/polycli_ulxly_claim_asset.md
@@ -124,6 +124,7 @@ The command also inherits flags from parent commands.
       --pretty-logs                        output logs in pretty format instead of JSON (default true)
       --private-key string                 hex encoded private key for sending transaction
       --proof-ger string                   if specified and using legacy mode, the proof will be generated against this GER
+      --proof-l1-info-tree-index uint32    if specified and using aggkit mode, the proof will be generated against this L1 Info Tree Index
       --rpc-url string                     RPC URL to send the transaction
       --transaction-receipt-timeout uint   timeout in seconds to wait for transaction receipt confirmation (default 60)
   -v, --verbosity string                   log level (string or int):

--- a/doc/polycli_ulxly_claim_message.md
+++ b/doc/polycli_ulxly_claim_message.md
@@ -129,6 +129,7 @@ The command also inherits flags from parent commands.
       --pretty-logs                        output logs in pretty format instead of JSON (default true)
       --private-key string                 hex encoded private key for sending transaction
       --proof-ger string                   if specified and using legacy mode, the proof will be generated against this GER
+      --proof-l1-info-tree-index uint32    if specified and using aggkit mode, the proof will be generated against this L1 Info Tree Index
       --rpc-url string                     RPC URL to send the transaction
       --transaction-receipt-timeout uint   timeout in seconds to wait for transaction receipt confirmation (default 60)
   -v, --verbosity string                   log level (string or int):


### PR DESCRIPTION
closes https://github.com/0xPolygon/devtools/issues/419

The `aggkit bridge service` requires the `l1-info-tree-index` to be provided to generate the proof for claiming an `asset` or `message`. The `l1-info-tree-index` is loaded automatically using the `network_id` and `deposit_count`.

The new flag `--proof-l1-info-tree-index` allows the user to force a specific `l1 info tree index` while claiming an `asset` or `message` via the `aggkit bridge service`