### PR TITLE
feat(sensor): gate transaction rebroadcast

### DIFF
--- a/cmd/p2p/sensor/sensor.go
+++ b/cmd/p2p/sensor/sensor.go
@@ -65,6 +65,13 @@ type (
 		MaxQueuedTxs                     int
 		ValidateBlockSigner              bool
 		CacheOnlyValidatedBlocks         bool
+		GateStaleTxs                     bool
+		GateStaleTxsRPC                  bool
+		RebroadcastMinTip                uint64
+		RebroadcastRateLimit             float64
+		RebroadcastBurst                 int
+		RebroadcastGateLogOnly           bool
+		AccountNoncesCache               ds.LRUOptions
 		HeimdallURL                      string
 		ValidatorSetRefresh              time.Duration
 		ShouldRunPprof                   bool
@@ -247,6 +254,39 @@ var SensorCmd = &cobra.Command{
 			}
 		}
 
+		// The gates only matter when the sensor echoes transactions at all.
+		broadcastsTxs := inputSensorParams.ShouldBroadcastTx || inputSensorParams.ShouldBroadcastTxHashes
+		if broadcastsTxs && inputSensorParams.RebroadcastMinTip == 0 {
+			log.Warn().
+				Msg("Rebroadcasting transactions with no tip floor; set --rebroadcast-min-tip (25gwei on Polygon) to stop echoing unminable transactions")
+		}
+
+		// Build the transaction rebroadcast gates. They only ever withhold an
+		// echo: every transaction the sensor sees is still recorded. The filter
+		// is nil when no gate is enabled, which the broadcast path treats as
+		// allow-everything.
+		var txFilter *p2p.TxFilter
+		if broadcastsTxs {
+			nonceRPC := ""
+			if inputSensorParams.GateStaleTxsRPC {
+				nonceRPC = inputSensorParams.RPC
+			}
+			txFilter, err = p2p.NewTxFilter(ctx, p2p.TxFilterOptions{
+				ChainID:        inputSensorParams.NetworkID,
+				GateStaleTxs:   inputSensorParams.GateStaleTxs,
+				NonceCache:     inputSensorParams.AccountNoncesCache,
+				NonceRPCURL:    nonceRPC,
+				MinTip:         inputSensorParams.RebroadcastMinTip,
+				RateLimit:      inputSensorParams.RebroadcastRateLimit,
+				RateLimitBurst: inputSensorParams.RebroadcastBurst,
+				LogOnly:        inputSensorParams.RebroadcastGateLogOnly,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to create transaction rebroadcast filter: %w", err)
+			}
+			defer txFilter.Close()
+		}
+
 		// Create peer connection manager for broadcasting transactions
 		// and managing the global blocks cache
 		conns := p2p.NewConns(p2p.ConnsOptions{
@@ -266,6 +306,7 @@ var SensorCmd = &cobra.Command{
 			MaxQueuedTxs:               inputSensorParams.MaxQueuedTxs,
 			ValidatorSet:               validators,
 			CacheOnlyValidatedBlocks:   inputSensorParams.CacheOnlyValidatedBlocks,
+			TxFilter:                   txFilter,
 		})
 
 		opts := p2p.EthProtocolOptions{
@@ -578,6 +619,29 @@ values multiply write volume by up to --max-peers rows per tick`)
 	f.BoolVar(&inputSensorParams.CacheOnlyValidatedBlocks, "cache-only-validated-blocks", true, "only cache and serve blocks signed by a known validator (unknown-signer blocks are still recorded to the database); has no effect without --validate-block-signer")
 	f.StringVar(&inputSensorParams.HeimdallURL, "heimdall-url", "https://heimdall-api.polygon.technology", "heimdall REST URL for the validator set (used to validate blocks before rebroadcast)")
 	f.DurationVar(&inputSensorParams.ValidatorSetRefresh, "validator-set-refresh", 5*time.Minute, "interval to refresh the validator set from heimdall")
+	f.BoolVar(&inputSensorParams.GateStaleTxs, "gate-stale-txs", true,
+		`only rebroadcast transactions whose nonce is at or above the sender's known
+next nonce; stale ones can never be mined, so echoing them only amplifies replay
+traffic (they are still recorded to the database)`)
+	f.BoolVar(&inputSensorParams.GateStaleTxsRPC, "gate-stale-txs-rpc", true,
+		`look up nonces from --rpc for senders not yet seen in a block; lookups are
+asynchronous and the transaction that triggers one is still rebroadcast`)
+	f.Var(&flag.GasValue{Val: &inputSensorParams.RebroadcastMinTip}, "rebroadcast-min-tip",
+		`withhold transactions offering less than this tip from rebroadcast, with unit
+support (e.g. "25gwei"); bor will not include anything below 25gwei on Polygon, so
+those are unminable regardless (0 disables)`)
+	f.Float64Var(&inputSensorParams.RebroadcastRateLimit, "rebroadcast-rate-limit", 0,
+		`cap rebroadcast throughput in transactions per second, a backstop that bounds
+amplification even when the gates above miss (0 for no limit)`)
+	f.IntVar(&inputSensorParams.RebroadcastBurst, "rebroadcast-burst", 0,
+		"token bucket depth for --rebroadcast-rate-limit (defaults to one second of the rate)")
+	f.BoolVar(&inputSensorParams.RebroadcastGateLogOnly, "rebroadcast-gate-log-only", false,
+		`evaluate the rebroadcast gates and count what they would drop, but rebroadcast
+everything anyway; use it to size the problem before enforcing`)
+	f.IntVar(&inputSensorParams.AccountNoncesCache.MaxSize, "max-account-nonces", 65536,
+		"maximum sender nonces to track for --gate-stale-txs (0 for no limit)")
+	f.DurationVar(&inputSensorParams.AccountNoncesCache.TTL, "account-nonces-ttl", time.Hour,
+		"time to live for tracked sender nonces (0 for no expiration)")
 	f.BoolVar(&inputSensorParams.ShouldRunPprof, "pprof", false, "run pprof server")
 	f.UintVar(&inputSensorParams.PprofPort, "pprof-port", 6060, "port pprof runs on")
 	f.BoolVar(&inputSensorParams.ShouldRunPrometheus, "prom", true, "run Prometheus server")

--- a/cmd/p2p/sensor/usage.md
+++ b/cmd/p2p/sensor/usage.md
@@ -80,6 +80,52 @@ The validator set is fetched from `--heimdall-url` at startup (the sensor aborts
 if this initial fetch fails) and refreshed on the `--validator-set-refresh`
 interval.
 
+### Transaction rebroadcast gates
+
+Rebroadcasting a transaction is only useful if that transaction could still be
+mined. Echoing one that cannot — a replayed historical transaction, or one
+priced below what the chain will include — amplifies junk across the network:
+the sensor fetches the body, then announces it to every peer. Because a sensor
+carries far more peers than an ordinary node, that amplification is large.
+
+Three gates apply when transaction rebroadcasting is on (`--broadcast-txs` or
+`--broadcast-tx-hashes`). They run cheapest-first and only ever withhold an
+*echo*: everything the sensor sees is still recorded to the database and still
+served to peers that ask for it, the same split `--validate-block-signer` uses
+for blocks.
+
+- **Tip floor** (`--rebroadcast-min-tip`, disabled by default): withholds
+  transactions offering less than the given tip, which accepts units — e.g.
+  `--rebroadcast-min-tip=25gwei`. Bor will not include anything below 25 gwei on
+  Polygon, so those transactions are unminable no matter what else is true. The
+  check needs no sender recovery and no lookup.
+- **Stale nonce** (`--gate-stale-txs`, enabled by default): withholds
+  transactions whose nonce is below their sender's next usable nonce. The sensor
+  tracks sender nonces from the transactions of every block it already observes,
+  so the common case costs nothing extra. Senders that have not appeared in an
+  observed block are looked up against `--rpc` asynchronously
+  (`--gate-stale-txs-rpc`, enabled by default); the transaction that triggers a
+  lookup is still rebroadcast, and the result gates later ones from that sender.
+  `--max-account-nonces` and `--account-nonces-ttl` size that map. Only blocks
+  that pass the signer check feed it, so a peer that is not a known validator
+  cannot poison a sender's nonce with a fabricated block and get that sender's
+  real transactions withheld.
+- **Rate cap** (`--rebroadcast-rate-limit`, disabled by default): a token bucket
+  over rebroadcast transactions per second, with `--rebroadcast-burst` as the
+  depth. It bounds worst-case amplification even when the gates above miss
+  something. It runs last, so transactions the other gates rejected do not spend
+  the budget.
+
+To size the problem before enforcing anything, run with
+`--rebroadcast-gate-log-only`: every gate is evaluated and its
+`sensor_rebroadcast_filtered` counters move, but nothing is actually withheld.
+
+Withheld transactions are counted by
+`sensor_rebroadcast_filtered{reason="stale_nonce"|"low_tip"|"rate_limited"}` and
+passing ones by `sensor_rebroadcast_allowed`. The nonce map is reported by
+`sensor_rebroadcast_known_senders`, and fallback lookups by
+`sensor_rebroadcast_nonce_lookups{result="ok"|"error"|"dropped"}`.
+
 ## Examples
 
 ### Mainnet

--- a/doc/polycli_p2p_sensor.md
+++ b/doc/polycli_p2p_sensor.md
@@ -101,6 +101,52 @@ The validator set is fetched from `--heimdall-url` at startup (the sensor aborts
 if this initial fetch fails) and refreshed on the `--validator-set-refresh`
 interval.
 
+### Transaction rebroadcast gates
+
+Rebroadcasting a transaction is only useful if that transaction could still be
+mined. Echoing one that cannot — a replayed historical transaction, or one
+priced below what the chain will include — amplifies junk across the network:
+the sensor fetches the body, then announces it to every peer. Because a sensor
+carries far more peers than an ordinary node, that amplification is large.
+
+Three gates apply when transaction rebroadcasting is on (`--broadcast-txs` or
+`--broadcast-tx-hashes`). They run cheapest-first and only ever withhold an
+*echo*: everything the sensor sees is still recorded to the database and still
+served to peers that ask for it, the same split `--validate-block-signer` uses
+for blocks.
+
+- **Tip floor** (`--rebroadcast-min-tip`, disabled by default): withholds
+  transactions offering less than the given tip, which accepts units — e.g.
+  `--rebroadcast-min-tip=25gwei`. Bor will not include anything below 25 gwei on
+  Polygon, so those transactions are unminable no matter what else is true. The
+  check needs no sender recovery and no lookup.
+- **Stale nonce** (`--gate-stale-txs`, enabled by default): withholds
+  transactions whose nonce is below their sender's next usable nonce. The sensor
+  tracks sender nonces from the transactions of every block it already observes,
+  so the common case costs nothing extra. Senders that have not appeared in an
+  observed block are looked up against `--rpc` asynchronously
+  (`--gate-stale-txs-rpc`, enabled by default); the transaction that triggers a
+  lookup is still rebroadcast, and the result gates later ones from that sender.
+  `--max-account-nonces` and `--account-nonces-ttl` size that map. Only blocks
+  that pass the signer check feed it, so a peer that is not a known validator
+  cannot poison a sender's nonce with a fabricated block and get that sender's
+  real transactions withheld.
+- **Rate cap** (`--rebroadcast-rate-limit`, disabled by default): a token bucket
+  over rebroadcast transactions per second, with `--rebroadcast-burst` as the
+  depth. It bounds worst-case amplification even when the gates above miss
+  something. It runs last, so transactions the other gates rejected do not spend
+  the budget.
+
+To size the problem before enforcing anything, run with
+`--rebroadcast-gate-log-only`: every gate is evaluated and its
+`sensor_rebroadcast_filtered` counters move, but nothing is actually withheld.
+
+Withheld transactions are counted by
+`sensor_rebroadcast_filtered{reason="stale_nonce"|"low_tip"|"rate_limited"}` and
+passing ones by `sensor_rebroadcast_allowed`. The nonce map is reported by
+`sensor_rebroadcast_known_senders`, and fallback lookups by
+`sensor_rebroadcast_nonce_lookups{result="ok"|"error"|"dropped"}`.
+
 ## Examples
 
 ### Mainnet
@@ -156,6 +202,7 @@ polycli p2p sensor amoy-nodes.json \
 ## Flags
 
 ```bash
+      --account-nonces-ttl duration       time to live for tracked sender nonces (0 for no expiration) (default 1h0m0s)
       --api-port uint                     port API server will listen on (default 8080)
       --blocks-cache-ttl duration         time to live for block cache entries (0 for no expiration) (default 10m0s)
   -b, --bootnodes string                  comma separated nodes used for bootstrapping
@@ -176,6 +223,11 @@ polycli p2p sensor amoy-nodes.json \
       --discovery-dns string              DNS discovery ENR tree URL
       --discovery-port int                UDP P2P discovery port (default 30303)
       --fork-id bytesHex                  hex encoded fork ID (omit 0x) (default 22D523B2)
+      --gate-stale-txs                    only rebroadcast transactions whose nonce is at or above the sender's known
+                                          next nonce; stale ones can never be mined, so echoing them only amplifies replay
+                                          traffic (they are still recorded to the database) (default true)
+      --gate-stale-txs-rpc                look up nonces from --rpc for senders not yet seen in a block; lookups are
+                                          asynchronous and the transaction that triggers one is still rebroadcast (default true)
       --genesis-hash string               genesis block hash (default "0xa9c28ce2141b56c474f1dc504bee9b01eb1bd7d1a507580d5519d4437a97de1b")
       --heimdall-url string               heimdall REST URL for the validator set (used to validate blocks before rebroadcast) (default "https://heimdall-api.polygon.technology")
   -h, --help                              help for sensor
@@ -184,6 +236,7 @@ polycli p2p sensor amoy-nodes.json \
       --known-txs-bloom-hashes uint       number of hash functions for known txs bloom filter (default 7)
       --known-txs-bloom-size uint         bloom filter size in bits for tracking known transactions per peer (default ~40KB per filter,
                                           optimized for ~32K elements with ~1% false positive rate) (default 327680)
+      --max-account-nonces int            maximum sender nonces to track for --gate-stale-txs (0 for no limit) (default 65536)
       --max-blocks int                    maximum blocks to track across all peers (0 for no limit) (default 1024)
   -D, --max-db-concurrency int            maximum number of concurrent database operations to perform (increasing this
                                           will result in less chance of missing data but can significantly increase memory usage) (default 10000)
@@ -208,6 +261,14 @@ polycli p2p sensor amoy-nodes.json \
       --prom-port uint                    port Prometheus runs on (default 2112)
       --proxy-rpc                         proxy unsupported RPC methods to the --rpc endpoint
       --proxy-rpc-timeout duration        timeout for proxied RPC requests (default 30s)
+      --rebroadcast-burst int             token bucket depth for --rebroadcast-rate-limit (defaults to one second of the rate)
+      --rebroadcast-gate-log-only         evaluate the rebroadcast gates and count what they would drop, but rebroadcast
+                                          everything anyway; use it to size the problem before enforcing
+      --rebroadcast-min-tip gas           withhold transactions offering less than this tip from rebroadcast, with unit
+                                          support (e.g. "25gwei"); bor will not include anything below 25gwei on Polygon, so
+                                          those are unminable regardless (0 disables)
+      --rebroadcast-rate-limit float      cap rebroadcast throughput in transactions per second, a backstop that bounds
+                                          amplification even when the gates above miss (0 for no limit)
       --requests-cache-ttl duration       time to live for requests cache entries (0 for no expiration) (default 5m0s)
       --rpc string                        RPC endpoint used to fetch latest block (default "https://polygon-rpc.com")
       --rpc-port uint                     port for JSON-RPC server to receive transactions (default 8545)

--- a/doc/polycli_p2p_sensor_metrics.md
+++ b/doc/polycli_p2p_sensor_metrics.md
@@ -66,6 +66,36 @@ Number of peers the sensor is connected to
 Metric Type: Gauge
 
 
+### sensor_rebroadcast_allowed
+Transactions passed to rebroadcast
+
+Metric Type: Counter
+
+
+### sensor_rebroadcast_filtered
+Transactions withheld from rebroadcast, by reason
+
+Metric Type: CounterVec
+
+Variable Labels:
+- reason
+
+
+### sensor_rebroadcast_known_senders
+Accounts in the nonce cache used by the stale-transaction gate
+
+Metric Type: Gauge
+
+
+### sensor_rebroadcast_nonce_lookups
+Account nonce lookups made against the RPC fallback, by result
+
+Metric Type: CounterVec
+
+Variable Labels:
+- result
+
+
 ### sensor_rpc_requests
 Number of RPC requests made
 

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/p2p/conns.go
+++ b/p2p/conns.go
@@ -51,6 +51,10 @@ type ConnsOptions struct {
 	// in the serving cache. Unknown-signer blocks are still persisted to the
 	// database but their header/body are not cached or served to peers.
 	CacheOnlyValidatedBlocks bool
+
+	// TxFilter, when non-nil, gates which peer-sourced transactions are
+	// rebroadcast. It does not affect what is recorded to the database.
+	TxFilter *TxFilter
 }
 
 // Conns manages a collection of active peer connections for transaction broadcasting.
@@ -106,6 +110,10 @@ type Conns struct {
 	// cacheOnlyValidated, when true, keeps only validator-signed blocks in the
 	// serving cache (unknown-signer blocks are recorded to the database only).
 	cacheOnlyValidated bool
+
+	// txFilter, when non-nil, gates transaction rebroadcasting. A nil filter
+	// allows everything (see TxFilter.Allow).
+	txFilter *TxFilter
 
 	// metrics tracks broadcast-related Prometheus metrics
 	metrics *metrics
@@ -164,6 +172,7 @@ func NewConns(opts ConnsOptions) *Conns {
 		maxQueuedTxs:               opts.MaxQueuedTxs,
 		validators:                 opts.ValidatorSet,
 		cacheOnlyValidated:         opts.CacheOnlyValidatedBlocks,
+		txFilter:                   opts.TxFilter,
 		metrics:                    newMetrics(),
 	}
 
@@ -636,6 +645,18 @@ func (c *Conns) FilterUnknownTxHashes(hashes []common.Hash) []common.Hash {
 func (c *Conns) MarkTxSeen(hash common.Hash) (firstSeen bool) {
 	existed := c.announcedTxs.Update(hash, func(v struct{}) struct{} { return v })
 	return !existed
+}
+
+// TxFilter returns the rebroadcast filter, which may be nil when no gate is
+// enabled. A nil filter allows everything.
+func (c *Conns) TxFilter() *TxFilter {
+	return c.txFilter
+}
+
+// ObserveMinedTxs feeds the transactions of an observed block to the
+// rebroadcast filter, which uses them to track sender nonces.
+func (c *Conns) ObserveMinedTxs(txs []*types.Transaction) {
+	c.txFilter.ObserveMined(txs)
 }
 
 // Blocks returns the global blocks cache.

--- a/p2p/datastructures/lru.go
+++ b/p2p/datastructures/lru.go
@@ -302,6 +302,14 @@ func (c *LRU[K, V]) Keys() []K {
 	return keys
 }
 
+// Len returns the number of entries in the cache. Entries whose TTL has passed
+// but that have not been evicted yet are still counted.
+func (c *LRU[K, V]) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}
+
 // AddBatch adds multiple key-value pairs to the cache.
 // Uses a single write lock for all additions, reducing lock contention
 // compared to calling Add in a loop. Keys and values must have the same length.

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -126,3 +126,33 @@ func newMetrics() *metrics {
 		}),
 	}
 }
+
+// Transaction rebroadcast filter metrics (see txfilter.go). These are
+// package-level rather than constructor-registered because a filter is built
+// per sensor but many per test run, and promauto panics on duplicate
+// registration.
+var (
+	txFilterDropped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sensor",
+		Name:      "rebroadcast_filtered",
+		Help:      "Transactions withheld from rebroadcast, by reason",
+	}, []string{"reason"})
+
+	txFilterAllowed = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "sensor",
+		Name:      "rebroadcast_allowed",
+		Help:      "Transactions passed to rebroadcast",
+	})
+
+	txFilterNonceLookups = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "sensor",
+		Name:      "rebroadcast_nonce_lookups",
+		Help:      "Account nonce lookups made against the RPC fallback, by result",
+	}, []string{"result"})
+
+	txFilterKnownSenders = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "sensor",
+		Name:      "rebroadcast_known_senders",
+		Help:      "Accounts in the nonce cache used by the stale-transaction gate",
+	})
+)

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -954,9 +954,28 @@ func (c *conn) processTransactions(ctx context.Context, txs []*types.Transaction
 		c.db.WriteTransactions(ctx, c.node, newTxs, tfs)
 	}
 
+	// Gate what gets echoed back out. Everything above this point is
+	// unconditional: the sensor records every transaction it sees. Only the
+	// rebroadcast is filtered, the same split the block path uses for signer
+	// validation. A nil filter allows everything.
+	bcastTxs := c.conns.TxFilter().Allow(newTxs)
+	if len(bcastTxs) == 0 {
+		return
+	}
+
+	// Recompute hashes from the filtered set so the announcement matches the
+	// bodies we are willing to serve.
+	bcastHashes := hashes
+	if len(bcastTxs) != len(newTxs) {
+		bcastHashes = make([]common.Hash, len(bcastTxs))
+		for i, tx := range bcastTxs {
+			bcastHashes[i] = tx.Hash()
+		}
+	}
+
 	// Broadcast transactions or hashes to other peers asynchronously
-	go c.conns.BroadcastTxs(types.Transactions(newTxs))
-	go c.conns.BroadcastTxHashes(hashes)
+	go c.conns.BroadcastTxs(types.Transactions(bcastTxs))
+	go c.conns.BroadcastTxHashes(bcastHashes)
 }
 
 // encodeBlockBody converts a block to an eth.BlockBody with RLP-encoded fields.
@@ -1229,6 +1248,13 @@ func (c *conn) handleBlockBodies(ctx context.Context, msg ethp2p.Msg) error {
 			Uncles:       blockUncles,
 			Withdrawals:  blockWithdrawals,
 		})
+
+		// Feed sender nonces to the rebroadcast filter. Only blocks whose
+		// header we hold get here, and when cache-only-validated is on that
+		// header is signer-validated -- so an unvalidated peer cannot poison
+		// the nonce map by serving a body full of high-nonce transactions.
+		c.conns.ObserveMinedTxs(blockTxs)
+
 		c.conns.UpdateHeadBlock(NewBlockPacket{
 			Block: block,
 			TD:    c.conns.HeadBlock().TD,
@@ -1380,6 +1406,13 @@ func (c *conn) handleNewBlock(ctx context.Context, msg ethp2p.Msg) error {
 			Msg("Skipping full block rebroadcast, signer not in validator set")
 		return nil
 	}
+
+	// Every mined transaction advances its sender's nonce, which is what the
+	// stale-transaction gate checks against. Gated on the same signer check as
+	// the rebroadcast below: a peer that is not a known validator must not be
+	// able to poison the nonce map with a fabricated block, which would make us
+	// withhold a victim sender's real transactions.
+	c.conns.ObserveMinedTxs(packet.Block.Transactions())
 
 	// Broadcast block or block hash to other peers asynchronously
 	go c.conns.BroadcastBlock(packet.Block, packet.TD)

--- a/p2p/txfilter.go
+++ b/p2p/txfilter.go
@@ -1,0 +1,326 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/time/rate"
+
+	ds "github.com/0xPolygon/polygon-cli/p2p/datastructures"
+)
+
+// Rebroadcast filter drop reasons, used as the metric label and in logs.
+const (
+	dropReasonStaleNonce  = "stale_nonce"
+	dropReasonLowTip      = "low_tip"
+	dropReasonRateLimited = "rate_limited"
+)
+
+const (
+	// nonceLookupQueueSize bounds the RPC fallback backlog. Lookups are a
+	// best-effort warm-up of the nonce cache, so a full queue drops the request
+	// rather than blocking the message loop.
+	nonceLookupQueueSize = 4096
+	// nonceLookupWorkers bounds concurrent eth_getTransactionCount calls.
+	nonceLookupWorkers = 4
+	// nonceLookupTimeout bounds a single fallback lookup.
+	nonceLookupTimeout = 10 * time.Second
+	// nonceLookupRetryAfter is how long a sender stays in the in-flight set,
+	// suppressing duplicate lookups for the same address.
+	nonceLookupRetryAfter = time.Minute
+)
+
+// TxFilterOptions configures the rebroadcast gates. The zero value gates
+// nothing, so a filter only does work for the gates that are turned on.
+type TxFilterOptions struct {
+	// ChainID selects the signer used to recover transaction senders.
+	ChainID uint64
+
+	// GateStaleTxs drops transactions whose nonce is below the sender's known
+	// next nonce. These can never be mined, so echoing them is pure
+	// amplification -- this is the gate that catches replayed history.
+	GateStaleTxs bool
+
+	// NonceCache sizes the sender -> next-nonce map that backs the stale gate.
+	NonceCache ds.LRUOptions
+
+	// NonceRPCURL, when set, is used to look up nonces for senders that have
+	// not been observed in a block yet. Lookups are asynchronous: the
+	// transaction that triggered one is allowed through, and the result gates
+	// later transactions from that sender.
+	NonceRPCURL string
+
+	// MinTip drops transactions offering less than this tip (in wei). On
+	// Polygon, bor will not include anything below 25 gwei, so those are
+	// unminable regardless of anything else. Zero disables the gate.
+	MinTip uint64
+
+	// RateLimit caps rebroadcast throughput in transactions per second, a
+	// backstop that bounds amplification even if the gates above miss. Zero or
+	// negative disables the cap.
+	RateLimit float64
+	// RateLimitBurst is the token bucket depth. Defaults to one second of
+	// RateLimit when unset.
+	RateLimitBurst int
+
+	// LogOnly evaluates every gate and records what would have been dropped,
+	// but rebroadcasts everything anyway. Use it to size the problem before
+	// turning the gates on.
+	LogOnly bool
+}
+
+// enabled reports whether any gate is configured.
+func (o TxFilterOptions) enabled() bool {
+	return o.GateStaleTxs || o.MinTip > 0 || o.RateLimit > 0
+}
+
+// TxFilter decides which transactions the sensor rebroadcasts. It never
+// affects what is recorded to the database: the sensor observes everything and
+// gates only the echo, the same split the block path uses for signer
+// validation.
+//
+// The gates run cheapest-first, and the rate limiter runs last so that
+// transactions dropped by an earlier gate do not consume budget.
+type TxFilter struct {
+	opts   TxFilterOptions
+	signer types.Signer
+	minTip *big.Int
+
+	// nonces maps a sender to the next nonce it can validly use. It is fed for
+	// free from the transactions of every block the sensor already observes,
+	// with the RPC fallback filling in senders that have not appeared in one.
+	nonces *ds.LRU[common.Address, uint64]
+
+	limiter *rate.Limiter
+
+	rpc      *ethclient.Client
+	lookups  chan common.Address
+	inflight *ds.LRU[common.Address, struct{}]
+}
+
+// NewTxFilter creates a transaction rebroadcast filter. It returns nil when no
+// gate is enabled, and callers must treat a nil filter as "allow everything"
+// (see TxFilter.Allow), so the no-gates path costs nothing.
+func NewTxFilter(ctx context.Context, opts TxFilterOptions) (*TxFilter, error) {
+	if !opts.enabled() {
+		return nil, nil
+	}
+
+	f := &TxFilter{
+		opts:   opts,
+		signer: types.LatestSignerForChainID(new(big.Int).SetUint64(opts.ChainID)),
+	}
+
+	if opts.MinTip > 0 {
+		f.minTip = new(big.Int).SetUint64(opts.MinTip)
+	}
+
+	if opts.RateLimit > 0 {
+		burst := opts.RateLimitBurst
+		if burst <= 0 {
+			burst = int(opts.RateLimit)
+		}
+		if burst <= 0 {
+			burst = 1
+		}
+		f.limiter = rate.NewLimiter(rate.Limit(opts.RateLimit), burst)
+	}
+
+	if opts.GateStaleTxs {
+		f.nonces = ds.NewLRU[common.Address, uint64](opts.NonceCache)
+
+		if opts.NonceRPCURL != "" {
+			client, err := ethclient.DialContext(ctx, opts.NonceRPCURL)
+			if err != nil {
+				return nil, fmt.Errorf("dialing nonce lookup rpc %s: %w", opts.NonceRPCURL, err)
+			}
+			f.rpc = client
+			f.lookups = make(chan common.Address, nonceLookupQueueSize)
+			f.inflight = ds.NewLRU[common.Address, struct{}](ds.LRUOptions{
+				MaxSize: nonceLookupQueueSize,
+				TTL:     nonceLookupRetryAfter,
+			})
+			for range nonceLookupWorkers {
+				go f.lookupWorker(ctx)
+			}
+		}
+	}
+
+	log.Info().
+		Bool("gate_stale_txs", opts.GateStaleTxs).
+		Bool("nonce_rpc_fallback", f.rpc != nil).
+		Uint64("min_tip_wei", opts.MinTip).
+		Float64("rate_limit", opts.RateLimit).
+		Bool("log_only", opts.LogOnly).
+		Msg("Transaction rebroadcast gates enabled")
+
+	return f, nil
+}
+
+// Close releases the RPC client used for nonce fallback lookups.
+func (f *TxFilter) Close() {
+	if f == nil || f.rpc == nil {
+		return
+	}
+	f.rpc.Close()
+}
+
+// ObserveMined records the sender nonces advanced by a mined block. Every block
+// the sensor sees maintains the stale gate for free: a mined transaction proves
+// its sender's next nonce is at least one higher.
+func (f *TxFilter) ObserveMined(txs []*types.Transaction) {
+	if f == nil || f.nonces == nil || len(txs) == 0 {
+		return
+	}
+
+	for _, tx := range txs {
+		sender, err := types.Sender(f.signer, tx)
+		if err != nil {
+			continue
+		}
+		f.setNonce(sender, tx.Nonce()+1)
+	}
+
+	txFilterKnownSenders.Set(float64(f.nonces.Len()))
+}
+
+// setNonce advances a sender's known next nonce, never lowering it. Blocks and
+// RPC responses can arrive out of order, so the highest value wins.
+func (f *TxFilter) setNonce(sender common.Address, next uint64) {
+	f.nonces.Update(sender, func(current uint64) uint64 {
+		if next > current {
+			return next
+		}
+		return current
+	})
+}
+
+// Allow returns the transactions that may be rebroadcast. A nil filter allows
+// everything, so callers do not need to check for one. In LogOnly mode every
+// transaction is returned, but the drop counters still move.
+func (f *TxFilter) Allow(txs []*types.Transaction) []*types.Transaction {
+	if f == nil || len(txs) == 0 {
+		return txs
+	}
+
+	allowed := make([]*types.Transaction, 0, len(txs))
+	for _, tx := range txs {
+		if reason, ok := f.reject(tx); ok {
+			txFilterDropped.WithLabelValues(reason).Inc()
+			log.Trace().
+				Stringer("hash", tx.Hash()).
+				Uint64("nonce", tx.Nonce()).
+				Str("reason", reason).
+				Msg("Withholding transaction from rebroadcast")
+			if !f.opts.LogOnly {
+				continue
+			}
+		} else {
+			txFilterAllowed.Inc()
+		}
+		allowed = append(allowed, tx)
+	}
+
+	return allowed
+}
+
+// reject applies each gate in increasing order of cost and reports the first
+// one that fires.
+func (f *TxFilter) reject(tx *types.Transaction) (reason string, rejected bool) {
+	// Cheapest: a tip below the chain's floor can never be included, and needs
+	// neither sender recovery nor any lookup.
+	if f.minTip != nil && tx.GasTipCap().Cmp(f.minTip) < 0 {
+		return dropReasonLowTip, true
+	}
+
+	// Costs an ecrecover, cached on the transaction by go-ethereum after the
+	// first call, and a map hit.
+	if f.nonces != nil && f.isStale(tx) {
+		return dropReasonStaleNonce, true
+	}
+
+	// Last, so that transactions the gates above rejected do not spend budget.
+	if f.limiter != nil && !f.limiter.Allow() {
+		return dropReasonRateLimited, true
+	}
+
+	return "", false
+}
+
+// isStale reports whether a transaction's nonce is below its sender's known
+// next nonce, meaning it cannot be mined. Senders that have not been observed
+// are not stale as far as we know: the transaction is allowed and, when the RPC
+// fallback is configured, a lookup is queued so later ones can be judged.
+func (f *TxFilter) isStale(tx *types.Transaction) bool {
+	sender, err := types.Sender(f.signer, tx)
+	if err != nil {
+		// Unsigned or malformed for this chain's signer. Not a staleness
+		// judgment, and the decode path already accepted it, so leave it alone.
+		return false
+	}
+
+	next, known := f.nonces.Get(sender)
+	if !known {
+		f.queueLookup(sender)
+		return false
+	}
+
+	return tx.Nonce() < next
+}
+
+// queueLookup schedules an asynchronous nonce lookup for an unobserved sender.
+// It never blocks: a full queue means the sender stays unknown for now.
+func (f *TxFilter) queueLookup(sender common.Address) {
+	if f.lookups == nil {
+		return
+	}
+
+	// Suppress duplicate lookups for the same sender while one is outstanding.
+	if existed := f.inflight.Update(sender, func(v struct{}) struct{} { return v }); existed {
+		return
+	}
+
+	select {
+	case f.lookups <- sender:
+	default:
+		txFilterNonceLookups.WithLabelValues("dropped").Inc()
+		f.inflight.Remove(sender)
+	}
+}
+
+// lookupWorker serves the RPC fallback queue until the context is cancelled.
+func (f *TxFilter) lookupWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case sender := <-f.lookups:
+			f.lookupNonce(ctx, sender)
+		}
+	}
+}
+
+// lookupNonce fetches a sender's next nonce and caches it. Failures are left
+// uncached so the sender can be retried once its in-flight entry expires.
+func (f *TxFilter) lookupNonce(ctx context.Context, sender common.Address) {
+	lookupCtx, cancel := context.WithTimeout(ctx, nonceLookupTimeout)
+	defer cancel()
+
+	nonce, err := f.rpc.NonceAt(lookupCtx, sender, nil)
+	if err != nil {
+		txFilterNonceLookups.WithLabelValues("error").Inc()
+		log.Debug().Err(err).Stringer("sender", sender).Msg("Failed to look up account nonce")
+		f.inflight.Remove(sender)
+		return
+	}
+
+	txFilterNonceLookups.WithLabelValues("ok").Inc()
+	f.setNonce(sender, nonce)
+	txFilterKnownSenders.Set(float64(f.nonces.Len()))
+}

--- a/p2p/txfilter_test.go
+++ b/p2p/txfilter_test.go
@@ -1,0 +1,445 @@
+package p2p
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	ds "github.com/0xPolygon/polygon-cli/p2p/datastructures"
+)
+
+const testChainID = 137
+
+var testSigner = types.LatestSignerForChainID(big.NewInt(testChainID))
+
+// newTestKey returns a key and its address.
+func newTestKey(t *testing.T) (*ecdsa.PrivateKey, common.Address) {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey)
+}
+
+// newTestTx signs a dynamic-fee transaction with the given nonce and tip.
+func newTestTx(t *testing.T, key *ecdsa.PrivateKey, nonce uint64, tipGwei int64) *types.Transaction {
+	t.Helper()
+	tip := new(big.Int).Mul(big.NewInt(tipGwei), big.NewInt(1e9))
+	tx, err := types.SignNewTx(key, testSigner, &types.DynamicFeeTx{
+		ChainID:   big.NewInt(testChainID),
+		Nonce:     nonce,
+		GasTipCap: tip,
+		GasFeeCap: new(big.Int).Add(tip, big.NewInt(1e9)),
+		Gas:       21000,
+		To:        &common.Address{},
+	})
+	if err != nil {
+		t.Fatalf("failed to sign tx: %v", err)
+	}
+	return tx
+}
+
+// newTestFilter builds a filter, failing the test if the options produce none.
+func newTestFilter(t *testing.T, opts TxFilterOptions) *TxFilter {
+	t.Helper()
+	if opts.ChainID == 0 {
+		opts.ChainID = testChainID
+	}
+	if opts.NonceCache.MaxSize == 0 {
+		opts.NonceCache.MaxSize = 1024
+	}
+	f, err := NewTxFilter(t.Context(), opts)
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	if f == nil {
+		t.Fatal("expected a filter, got nil")
+	}
+	t.Cleanup(f.Close)
+	return f
+}
+
+// hashesOf is a readable form for comparing allow results.
+func hashesOf(txs []*types.Transaction) []common.Hash {
+	out := make([]common.Hash, len(txs))
+	for i, tx := range txs {
+		out[i] = tx.Hash()
+	}
+	return out
+}
+
+func TestTxFilterDisabledByDefault(t *testing.T) {
+	f, err := NewTxFilter(t.Context(), TxFilterOptions{ChainID: testChainID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f != nil {
+		t.Fatal("expected nil filter when no gate is enabled")
+	}
+
+	// A nil filter must behave as allow-everything for both entry points.
+	key, _ := newTestKey(t)
+	txs := []*types.Transaction{newTestTx(t, key, 0, 30)}
+	if got := f.Allow(txs); len(got) != 1 {
+		t.Errorf("nil filter allowed %d txs, want 1", len(got))
+	}
+	f.ObserveMined(txs) // must not panic
+}
+
+func TestTxFilterGasFloor(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{MinTip: 25e9})
+
+	key, _ := newTestKey(t)
+	lowTip := newTestTx(t, key, 0, 1)
+	atFloor := newTestTx(t, key, 1, 25)
+	aboveFloor := newTestTx(t, key, 2, 30)
+
+	before := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonLowTip))
+	allowed := f.Allow([]*types.Transaction{lowTip, atFloor, aboveFloor})
+	after := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonLowTip))
+
+	want := []common.Hash{atFloor.Hash(), aboveFloor.Hash()}
+	if got := hashesOf(allowed); len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("allowed = %v, want %v", got, want)
+	}
+	if delta := after - before; delta != 1 {
+		t.Errorf("low_tip drops = %v, want 1", delta)
+	}
+}
+
+func TestTxFilterStaleNonceFromObservedBlock(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{GateStaleTxs: true})
+
+	key, addr := newTestKey(t)
+
+	// Before observing anything, an unknown sender is not judged stale.
+	old := newTestTx(t, key, 3, 30)
+	if got := f.Allow([]*types.Transaction{old}); len(got) != 1 {
+		t.Fatalf("unknown sender: allowed %d txs, want 1 (fail open)", len(got))
+	}
+
+	// A mined transaction at nonce 7 proves the next nonce is 8.
+	f.ObserveMined([]*types.Transaction{newTestTx(t, key, 7, 30)})
+
+	if next, ok := f.nonces.Peek(addr); !ok || next != 8 {
+		t.Fatalf("tracked nonce = %d (present %v), want 8", next, ok)
+	}
+
+	stale := newTestTx(t, key, 7, 30)
+	alsoStale := newTestTx(t, key, 0, 30)
+	current := newTestTx(t, key, 8, 30)
+	future := newTestTx(t, key, 12, 30)
+
+	before := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonStaleNonce))
+	allowed := f.Allow([]*types.Transaction{stale, alsoStale, current, future})
+	after := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonStaleNonce))
+
+	want := []common.Hash{current.Hash(), future.Hash()}
+	if got := hashesOf(allowed); len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("allowed = %v, want %v", got, want)
+	}
+	if delta := after - before; delta != 2 {
+		t.Errorf("stale_nonce drops = %v, want 2", delta)
+	}
+}
+
+func TestTxFilterObservedNonceNeverGoesBackwards(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{GateStaleTxs: true})
+	key, addr := newTestKey(t)
+
+	f.ObserveMined([]*types.Transaction{newTestTx(t, key, 9, 30)})
+	// An out-of-order block carrying an older transaction must not lower the
+	// tracked nonce, or stale transactions would start passing again.
+	f.ObserveMined([]*types.Transaction{newTestTx(t, key, 2, 30)})
+
+	if next, _ := f.nonces.Peek(addr); next != 10 {
+		t.Errorf("tracked nonce = %d, want 10", next)
+	}
+}
+
+func TestTxFilterRateLimit(t *testing.T) {
+	// One token per second with a burst of 2: the third transaction is capped.
+	f := newTestFilter(t, TxFilterOptions{RateLimit: 1, RateLimitBurst: 2})
+
+	key, _ := newTestKey(t)
+	txs := []*types.Transaction{
+		newTestTx(t, key, 0, 30),
+		newTestTx(t, key, 1, 30),
+		newTestTx(t, key, 2, 30),
+		newTestTx(t, key, 3, 30),
+	}
+
+	before := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonRateLimited))
+	allowed := f.Allow(txs)
+	after := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonRateLimited))
+
+	if len(allowed) != 2 {
+		t.Errorf("allowed %d txs, want 2 (the burst)", len(allowed))
+	}
+	if delta := after - before; delta != 2 {
+		t.Errorf("rate_limited drops = %v, want 2", delta)
+	}
+}
+
+func TestTxFilterRejectedTxsDoNotSpendRateBudget(t *testing.T) {
+	// The gates run cheapest-first and the limiter runs last, so a flood of
+	// unminable transactions must not consume the budget for good ones.
+	f := newTestFilter(t, TxFilterOptions{MinTip: 25e9, RateLimit: 1, RateLimitBurst: 1})
+
+	key, _ := newTestKey(t)
+	txs := []*types.Transaction{
+		newTestTx(t, key, 0, 1),
+		newTestTx(t, key, 1, 1),
+		newTestTx(t, key, 2, 1),
+		newTestTx(t, key, 3, 1),
+		newTestTx(t, key, 4, 30),
+	}
+
+	allowed := f.Allow(txs)
+	if len(allowed) != 1 {
+		t.Fatalf("allowed %d txs, want 1", len(allowed))
+	}
+	if allowed[0].Nonce() != 4 {
+		t.Errorf("allowed tx nonce = %d, want 4 (the well-priced one)", allowed[0].Nonce())
+	}
+}
+
+func TestTxFilterLogOnly(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{MinTip: 25e9, GateStaleTxs: true, LogOnly: true})
+
+	key, _ := newTestKey(t)
+	f.ObserveMined([]*types.Transaction{newTestTx(t, key, 5, 30)})
+
+	txs := []*types.Transaction{
+		newTestTx(t, key, 0, 1),  // low tip and stale
+		newTestTx(t, key, 6, 30), // fine
+	}
+
+	before := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonLowTip))
+	allowed := f.Allow(txs)
+	after := testutil.ToFloat64(txFilterDropped.WithLabelValues(dropReasonLowTip))
+
+	if len(allowed) != 2 {
+		t.Errorf("log-only allowed %d txs, want 2 (nothing withheld)", len(allowed))
+	}
+	if delta := after - before; delta != 1 {
+		t.Errorf("low_tip drops = %v, want 1 (counted but not enforced)", delta)
+	}
+}
+
+func TestTxFilterUnsignedTxIsNotJudgedStale(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{GateStaleTxs: true})
+
+	// No signature, so the sender cannot be recovered. The decode path already
+	// accepted it; the staleness gate has no opinion.
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   big.NewInt(testChainID),
+		Nonce:     0,
+		GasTipCap: big.NewInt(1e9),
+		GasFeeCap: big.NewInt(2e9),
+		Gas:       21000,
+		To:        &common.Address{},
+	})
+
+	if got := f.Allow([]*types.Transaction{tx}); len(got) != 1 {
+		t.Errorf("allowed %d txs, want 1", len(got))
+	}
+}
+
+// nonceRPC is a fake JSON-RPC endpoint serving eth_getTransactionCount.
+type nonceRPC struct {
+	t      *testing.T
+	nonces map[common.Address]uint64
+	calls  atomic.Int64
+}
+
+func newNonceRPC(t *testing.T, nonces map[common.Address]uint64) (*nonceRPC, string) {
+	t.Helper()
+	n := &nonceRPC{t: t, nonces: nonces}
+	server := httptest.NewServer(http.HandlerFunc(n.handle))
+	t.Cleanup(server.Close)
+	return n, server.URL
+}
+
+func (n *nonceRPC) handle(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Params []any           `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var result string
+	switch req.Method {
+	case "eth_chainId":
+		result = "0x89"
+	case "eth_getTransactionCount":
+		n.calls.Add(1)
+		addr := common.HexToAddress(req.Params[0].(string))
+		result = fmt.Sprintf("0x%x", n.nonces[addr])
+	default:
+		http.Error(w, "unexpected method "+req.Method, http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%q}`, req.ID, result); err != nil {
+		n.t.Errorf("failed to write rpc response: %v", err)
+	}
+}
+
+func TestTxFilterNonceRPCFallback(t *testing.T) {
+	key, addr := newTestKey(t)
+	rpc, url := newNonceRPC(t, map[common.Address]uint64{addr: 42})
+
+	f := newTestFilter(t, TxFilterOptions{GateStaleTxs: true, NonceRPCURL: url})
+
+	// First sight of an unknown sender: allowed, and a lookup is queued.
+	if got := f.Allow([]*types.Transaction{newTestTx(t, key, 5, 30)}); len(got) != 1 {
+		t.Fatalf("allowed %d txs, want 1 (fail open on unknown sender)", len(got))
+	}
+
+	// Once the lookup lands, the sender is known and stale txs are withheld.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if next, ok := f.nonces.Peek(addr); ok && next == 42 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("nonce lookup did not populate the cache")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := f.Allow([]*types.Transaction{newTestTx(t, key, 5, 30)}); len(got) != 0 {
+		t.Errorf("allowed %d stale txs after lookup, want 0", len(got))
+	}
+	if got := f.Allow([]*types.Transaction{newTestTx(t, key, 42, 30)}); len(got) != 1 {
+		t.Errorf("allowed %d current txs, want 1", len(got))
+	}
+	if calls := rpc.calls.Load(); calls != 1 {
+		t.Errorf("rpc lookups = %d, want 1", calls)
+	}
+}
+
+func TestTxFilterNonceRPCFallbackDedupesInFlight(t *testing.T) {
+	key, addr := newTestKey(t)
+	rpc, url := newNonceRPC(t, map[common.Address]uint64{addr: 3})
+
+	f := newTestFilter(t, TxFilterOptions{GateStaleTxs: true, NonceRPCURL: url})
+
+	// Many transactions from the same unknown sender must not fan out into many
+	// lookups.
+	txs := make([]*types.Transaction, 0, 50)
+	for i := range uint64(50) {
+		txs = append(txs, newTestTx(t, key, i, 30))
+	}
+	f.Allow(txs)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, ok := f.nonces.Peek(addr); ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("nonce lookup did not populate the cache")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if calls := rpc.calls.Load(); calls != 1 {
+		t.Errorf("rpc lookups = %d, want 1 for a single sender", calls)
+	}
+}
+
+func TestTxFilterNoRPCFallbackWhenUnset(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{GateStaleTxs: true})
+	if f.lookups != nil || f.rpc != nil {
+		t.Error("expected no RPC fallback machinery when NonceRPCURL is empty")
+	}
+
+	key, _ := newTestKey(t)
+	if got := f.Allow([]*types.Transaction{newTestTx(t, key, 0, 30)}); len(got) != 1 {
+		t.Errorf("allowed %d txs, want 1", len(got))
+	}
+}
+
+func TestTxFilterConcurrentAccess(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{
+		GateStaleTxs: true,
+		MinTip:       25e9,
+		RateLimit:    1e6,
+		NonceCache:   ds.LRUOptions{MaxSize: 128},
+	})
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key, _ := newTestKey(t)
+			for n := range uint64(20) {
+				tx := newTestTx(t, key, n, 30)
+				f.ObserveMined([]*types.Transaction{tx})
+				f.Allow([]*types.Transaction{tx})
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestTxFilterAllowEmpty(t *testing.T) {
+	f := newTestFilter(t, TxFilterOptions{MinTip: 25e9})
+	if got := f.Allow(nil); got != nil {
+		t.Errorf("Allow(nil) = %v, want nil", got)
+	}
+}
+
+func TestTxFilterContextCancellationStopsWorkers(t *testing.T) {
+	key, addr := newTestKey(t)
+	_, url := newNonceRPC(t, map[common.Address]uint64{addr: 1})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	f, err := NewTxFilter(ctx, TxFilterOptions{
+		ChainID:      testChainID,
+		GateStaleTxs: true,
+		NonceCache:   ds.LRUOptions{MaxSize: 16},
+		NonceRPCURL:  url,
+	})
+	if err != nil {
+		t.Fatalf("failed to create filter: %v", err)
+	}
+	defer f.Close()
+
+	cancel()
+	// Queued work after cancellation must not block the caller.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.Allow([]*types.Transaction{newTestTx(t, key, 0, 30)})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Allow blocked after context cancellation")
+	}
+}


### PR DESCRIPTION
> Draft: the gate logic and defaults are worth arguing about before this lands. See **Open questions** at the bottom.

## Problem

The sensor rebroadcasts every transaction it can fetch a body for. The only gate is novelty to its own cache (`p2p/protocol.go`, `processTransactions`):

```go
hashes := c.conns.AddTxs(newTxs)
if len(newTxs) > 0 { c.db.WriteTransactions(ctx, c.node, newTxs, tfs) }
go c.conns.BroadcastTxs(types.Transactions(newTxs))
go c.conns.BroadcastTxHashes(hashes)
```

No staleness check, no price check. So when a replay fleet announces week-old hashes, the sensor dutifully fetches the real old bodies and re-announces them — and `BroadcastTxHashes` fans out to *every* peer with `--max-peers` defaulting to 2000. One unminable transaction becomes up to 2000 announcements. On our Amoy vantage that is the bulk of the sensor's "firsts": ~47k unverified against 3,903 verified.

The sensor is not generating junk, it is amplifying it. It also pays inbound bandwidth fetching those bodies before paying outbound to echo them.

## Change

Three gates at that one choke point, cheapest-first:

| gate | flag | default | cost | catches |
|---|---|---|---|---|
| Tip floor | `--rebroadcast-min-tip` | off | none — no ecrecover, no lookup | transactions priced below what the chain will include |
| Stale nonce | `--gate-stale-txs` | **on** | one ecrecover (cached on the tx) + a map hit | replayed history, at any age |
| Rate cap | `--rebroadcast-rate-limit` | off | none | bounds worst case when the gates above miss |

The rate cap runs **last**, so transactions the other gates rejected do not spend its budget — there is a test pinning that.

**The nonce map is free.** Every block the sensor already observes proves `sender -> nonce+1` for each of its transactions, so the common case adds no lookups at all. Senders never seen in a block are resolved against `--rpc` asynchronously (bounded queue, 4 workers, in-flight dedup so 50 transactions from one unknown sender produce one lookup); the transaction that triggers a lookup is allowed through and the result gates later ones.

**Nothing changes about what is recorded.** The gates sit strictly between the database write and the broadcast calls — the same split `--validate-block-signer` already uses for blocks. A sensor that stops observing the replay fleet has lost the thing it is for.

### Security note

The nonce feed is gated behind the existing block signer check. A peer cannot forge signatures, but it *can* wrap a victim's real high-nonce queued transaction in a fabricated block, pushing the victim's tracked nonce to 101 so we withhold their legitimate transactions 5–100. Feeding only from signer-validated blocks closes that; it costs nothing when `--validate-block-signer=false`, since `RecoverSigner` returns `known=true` with no validator set.

### Measuring first

`--rebroadcast-gate-log-only` evaluates every gate and moves its counters while withholding nothing, so you can size the problem before enforcing. New metrics: `sensor_rebroadcast_filtered{reason="stale_nonce"|"low_tip"|"rate_limited"}`, `sensor_rebroadcast_allowed`, `sensor_rebroadcast_known_senders`, `sensor_rebroadcast_nonce_lookups{result}`.

## Testing

14 new tests in `p2p/txfilter_test.go`, `-race` clean: each gate in isolation, the cheapest-first ordering, nonce never moving backwards on out-of-order blocks, unknown sender failing open, unsigned transaction not judged, RPC fallback populating the cache and then gating, lookup dedup, log-only counting without enforcing, nil filter allowing everything, cancellation, and concurrent access. Full suite, `go vet`, and `golangci-lint` all pass.

Smoke-tested the built binary against a public Amoy endpoint:

- gates log their resolved config at startup (`gate_stale_txs:true, nonce_rpc_fallback:true, min_tip_wei:25000000000, rate_limit:500`)
- the no-tip-floor warning fires when broadcasting with no floor set
- `--broadcast-tx-hashes=false` constructs no filter at all
- `--rebroadcast-gate-log-only` propagates

**Not tested:** behavior under a live replay flood. The gates are unit-tested against synthetic transactions; what fraction of real sensor echo they withhold is exactly what `--rebroadcast-gate-log-only` is for, and I would run that on one sensor before enforcing anywhere.

## Open questions

1. **Should `--rebroadcast-min-tip` default to `25gwei`?** I left it off. 25 gwei is bor's floor and every other default in this command is Polygon-specific (`--rpc`, `--heimdall-url`), but `--network-id` is required, so someone on another chain could get everything silently withheld. Compromise for now: startup logs a warning naming 25gwei when broadcasting with no floor. Happy to flip it.
2. **Should the rate cap default to a number rather than off?** A backstop that is off by default is not much of a backstop, but a wrong value throttles legitimate flow. I would rather pick it from log-only data.
3. **`--gate-stale-txs` defaults on.** Consistent with `--validate-block-signer=true`, and it only engages when transaction rebroadcasting is explicitly enabled — but it is a behavior change for anyone running with `--broadcast-tx-hashes` today.
4. Fanout is untouched and is the other multiplier: `BroadcastTxHashes` still goes to all ~2000 peers. A `--broadcast-fanout=sqrt` knob would cut announce volume ~97% independently of whether these gates are correct. Deliberately left for a separate PR.

One dependency note: `go mod tidy` added `kylelemons/godebug` as an **indirect** dependency, pulled in by `prometheus/testutil` which the tests use for counter assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
