### PR TITLE
refactor(wallet): append the EIP-191 prefix directly

### DIFF
--- a/cmd/heimdall/wallet/eip191.go
+++ b/cmd/heimdall/wallet/eip191.go
@@ -19,7 +19,7 @@ const personalSignPrefix = "\x19Ethereum Signed Message:\n"
 // Matches the hash that MetaMask, ethers.js, viem, cast, and all other
 // mainstream Ethereum tooling use for message signing.
 func personalSignHash(message []byte) []byte {
-	prefix := []byte(fmt.Sprintf("%s%d", personalSignPrefix, len(message)))
+	prefix := fmt.Appendf(nil, "%s%d", personalSignPrefix, len(message))
 	payload := append(prefix, message...)
 	return crypto.Keccak256(payload)
 }


### PR DESCRIPTION
# Description

Build the EIP-191 personal_sign prefix with fmt.Appendf instead of fmt.Sprintf followed by []byte conversion. The prefix bytes, message length encoding, and resulting Keccak-256 digest are unchanged.

## Jira / Linear Tickets

N/A

# Testing

- [x] go test ./cmd/heimdall/wallet -count=1