### PR TITLE
feat(loadtest): --sync-txs for eth_sendRawTransactionSync, plus two runner fixes

### DIFF
--- a/cmd/fund/cmd.go
+++ b/cmd/fund/cmd.go
@@ -38,6 +38,10 @@ type cmdFundParams struct {
 
 	RateLimit float64
 
+	// Gas price parameters
+	GasPrice         uint64
+	PriorityGasPrice uint64
+
 	// ERC20 specific parameters
 	TokenAddress   string
 	TokenAmount    *big.Int
@@ -124,6 +128,10 @@ func init() {
 
 	// RPC parameters.
 	f.Float64Var(&params.RateLimit, "rate-limit", 4, "requests per second limit (use negative value to remove limit)")
+
+	// Gas price parameters.
+	f.Var(&flag.GasValue{Val: &params.GasPrice}, "gas-price", "gas price with unit support (e.g., \"100gwei\", \"1000000000\")")
+	f.Var(&flag.GasValue{Val: &params.PriorityGasPrice}, "priority-gas-price", "gas tip for EIP-1559 with unit support (e.g., \"2gwei\")")
 }
 
 func checkFlags() error {
@@ -139,6 +147,11 @@ func checkFlags() error {
 	}
 	if params.OutputFile == "" {
 		return errors.New("the output file is not specified")
+	}
+
+	// Validate gas price parameters
+	if params.GasPrice != 0 && params.PriorityGasPrice != 0 && params.GasPrice < params.PriorityGasPrice {
+		return errors.New("gas price must be greater than or equal to priority gas price")
 	}
 
 	// ERC20 specific validations

--- a/cmd/fund/fund.go
+++ b/cmd/fund/fund.go
@@ -54,6 +54,9 @@ func runFunding(ctx context.Context) error {
 		log.Error().Err(err).Msg("Unable create transaction signer")
 		return err
 	}
+	if err = applyGasPriceOverrides(ctx, c, tops); err != nil {
+		return err
+	}
 
 	var addresses []common.Address
 	var privateKeys []*ecdsa.PrivateKey
@@ -181,6 +184,54 @@ func dialRpc(ctx context.Context) (*ethclient.Client, error) {
 }
 
 // Initialize parameters.
+// chainSupportsEIP1559 reports whether the chain supports EIP-1559 dynamic fee
+// transactions, caching the result of the first lookup.
+var chainSupportsEIP1559Cache *bool
+
+func chainSupportsEIP1559(ctx context.Context, c *ethclient.Client) (bool, error) {
+	if chainSupportsEIP1559Cache != nil {
+		return *chainSupportsEIP1559Cache, nil
+	}
+	header, err := c.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("unable to fetch latest block header: %w", err)
+	}
+	supported := header.BaseFee != nil
+	chainSupportsEIP1559Cache = &supported
+	return supported, nil
+}
+
+// applyGasPriceOverrides applies the --gas-price and --priority-gas-price flag
+// values to the given transactor. On EIP-1559 chains, --gas-price sets the max
+// fee per gas and --priority-gas-price sets the gas tip cap; on legacy chains,
+// --gas-price sets the gas price and --priority-gas-price is ignored. Fields
+// without a corresponding flag are left nil so the client suggests them.
+func applyGasPriceOverrides(ctx context.Context, c *ethclient.Client, tops *bind.TransactOpts) error {
+	if params.GasPrice == 0 && params.PriorityGasPrice == 0 {
+		return nil
+	}
+	supportsEIP1559, err := chainSupportsEIP1559(ctx, c)
+	if err != nil {
+		return err
+	}
+	if supportsEIP1559 {
+		if params.GasPrice != 0 {
+			tops.GasFeeCap = new(big.Int).SetUint64(params.GasPrice)
+		}
+		if params.PriorityGasPrice != 0 {
+			tops.GasTipCap = new(big.Int).SetUint64(params.PriorityGasPrice)
+		}
+		return nil
+	}
+	if params.PriorityGasPrice != 0 {
+		log.Warn().Msg("Chain does not support EIP-1559, ignoring --priority-gas-price")
+	}
+	if params.GasPrice != 0 {
+		tops.GasPrice = new(big.Int).SetUint64(params.GasPrice)
+	}
+	return nil
+}
+
 func initializeParams(ctx context.Context, c *ethclient.Client) (*ecdsa.PrivateKey, *big.Int, error) {
 	// Parse the private key.
 	trimmedHexPrivateKey := strings.TrimPrefix(params.PrivateKey, "0x")
@@ -223,7 +274,11 @@ func deployOrInstantiateFunderContract(ctx context.Context, c *ethclient.Client,
 		// Note: `funderContractBalanceInWei` represents the initial balance of the Funder contract.
 		// The contract needs initial funds to be able to fund wallets.
 		funderContractBalanceInWei := new(big.Int).Mul(fundingAmountInWei, big.NewInt(int64(numAddresses)))
-		if err = util.SendTx(ctx, c, privateKey, &contractAddress, funderContractBalanceInWei, nil, uint64(30000)); err != nil {
+		var gasPrice *big.Int
+		if params.GasPrice != 0 {
+			gasPrice = new(big.Int).SetUint64(params.GasPrice)
+		}
+		if err = util.SendTx(ctx, c, privateKey, &contractAddress, funderContractBalanceInWei, gasPrice, nil, uint64(30000)); err != nil {
 			return nil, err
 		}
 	} else {
@@ -406,6 +461,9 @@ func fundWalletsWithMulticall3(ctx context.Context, c *ethclient.Client, tops *b
 
 		if uint64(len(accs)) == accsToFundPerTx || i == len(wallets)-1 {
 			wg.Add(1)
+			// Give each goroutine its own copy since the multicall3 helpers
+			// mutate tops.Value.
+			topsCopy := *tops
 			go func(tops *bind.TransactOpts, accs []common.Address) {
 				defer wg.Done()
 				var iErr error
@@ -443,7 +501,7 @@ func fundWalletsWithMulticall3(ctx context.Context, c *ethclient.Client, tops *b
 					Uint64("of", uint64(len(wallets))).
 					Msg("multicall3 transaction to fund accounts sent")
 				txsCh <- tx
-			}(tops, accs)
+			}(&topsCopy, accs)
 			accs = []common.Address{}
 		}
 	}
@@ -615,6 +673,9 @@ func approveSpenderForWallets(ctx context.Context, c *ethclient.Client, tokenAdd
 		walletTops, err := bind.NewKeyedTransactorWithChainID(walletPrivateKey, chainID)
 		if err != nil {
 			log.Error().Err(err).Str("wallet", wallet.String()).Msg("Unable to create transaction signer for wallet")
+			return err
+		}
+		if err = applyGasPriceOverrides(ctx, c, walletTops); err != nil {
 			return err
 		}
 

--- a/cmd/loadtest/cmd.go
+++ b/cmd/loadtest/cmd.go
@@ -116,6 +116,15 @@ func initPersistentFlags() {
 	pf.BoolVar(&cfg.EthCallOnlyLatestBlock, "eth-call-only-latest", false, "execute on latest block instead of original block in call-only mode with recall")
 	pf.BoolVar(&cfg.OutputRawTxOnly, "output-raw-tx-only", false, "output raw signed transaction hex without sending (works with most modes except RPC and UniswapV3)")
 	pf.BoolVar(&cfg.PrivateTxs, "private-txs", false, "send transactions via eth_sendRawTransactionPrivate")
+	pf.BoolVar(&cfg.SyncTxs, "sync-txs", false,
+		`send transactions via eth_sendRawTransactionSync (EIP-7966), which blocks until
+the node has a receipt; useful for measuring preconfirmation latency`)
+	pf.BoolVar(&cfg.SyncTxTimeoutInt, "sync-tx-timeout-int", false,
+		`send the --sync-tx-timeout value as a bare JSON integer instead of a hex quantity;
+bor wants hex (the default), while servers implementing EIP-7966 literally want an integer`)
+	pf.DurationVar(&cfg.SyncTxTimeout, "sync-tx-timeout", 0,
+		`maximum time the node should wait for a receipt with --sync-txs, sent in whole
+milliseconds (0 omits the parameter so the node applies its own default)`)
 	pf.Uint64Var(&cfg.EthAmountInWei, "eth-amount-in-wei", 0, "amount of ether in wei to send per transaction")
 	pf.Float64Var(&cfg.RateLimit, "rate-limit", 4, "requests per second limit (use negative value to remove limit)")
 	pf.DurationVar(&cfg.RateLimitRampDuration, "rate-limit-ramp-duration", 0, "linearly ramp rate limit from max(1% of --rate-limit, 1 TPS) to full --rate-limit over this duration (e.g. 3m; 0 disables ramp)")

--- a/cmd/loadtest/cmd.go
+++ b/cmd/loadtest/cmd.go
@@ -211,6 +211,10 @@ v3, uniswapv3 - perform UniswapV3 swaps`)
 	f.BoolVar(&cfg.WaitForReceipt, "wait-for-receipt", false, "wait for transaction receipt to be mined instead of just sending")
 	f.UintVar(&cfg.ReceiptRetryMax, "receipt-retry-max", 30, "maximum polling attempts for transaction receipt with --wait-for-receipt")
 	f.UintVar(&cfg.ReceiptRetryDelay, "receipt-retry-initial-delay-ms", 100, "initial delay in milliseconds for receipt polling (uses exponential backoff with jitter)")
+	f.DurationVar(&cfg.ReceiptPollInterval, "receipt-poll-interval", 0,
+		`fixed interval between receipt polls with --wait-for-receipt; when set, polling is
+bounded only by the receipt timeout and --receipt-retry-max is ignored (0 uses
+exponential backoff with jitter)`)
 	f.BoolVar(&cfg.CheckBalanceBeforeFunding, "check-balance-before-funding", false, "check account balance before funding sending accounts (saves gas when accounts are already funded)")
 }
 

--- a/cmd/loadtest/loadtestUsage.md
+++ b/cmd/loadtest/loadtestUsage.md
@@ -125,6 +125,15 @@ it waits on chain events and requires both a block number and a block hash befor
 answering, so `speculative` stays at zero. The speculative path needs bor's
 preconfirmation pipeline (`SubmitTxForPreconf` and the preconfirmation receipt index).
 
+At verbosity 700 (trace) each synchronous submission is also logged individually: the
+node's raw receipt verbatim as JSON on success, or the RPC error with its code and data on
+failure. Pair with `--log-format json` for machine-parseable lines that can be checked for
+correctness later, e.g. by diffing against `eth_getTransactionReceipt`:
+
+```bash
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs -v 700 --log-format json
+```
+
 Like `--private-txs`, `--sync-txs` is only supported by `transaction`, `blob`,
 `contract-call`, and `recall`, and the two flags are mutually exclusive.
 

--- a/cmd/loadtest/loadtestUsage.md
+++ b/cmd/loadtest/loadtestUsage.md
@@ -66,6 +66,70 @@ $ polycli loadtest --rpc-url http://fullnode:8545 --send-rpc-url http://broadcas
 
 Like `--private-txs`, this flag is only supported by the modes that broadcast transactions explicitly: `transaction`, `blob`, `contract-call`, and `recall`.
 
+### Synchronous Sending (EIP-7966)
+
+`--sync-txs` broadcasts with [`eth_sendRawTransactionSync`][eip-7966] instead of
+`eth_sendRawTransaction`. That call does not return when the transaction is accepted; it
+returns when the node has a receipt for it, or fails when its timeout elapses. On a chain
+that preconfirms, the receipt can arrive well before canonical inclusion, which is what
+makes this useful for measuring preconfirmation latency.
+
+```bash
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs --concurrency 20
+```
+
+`--sync-tx-timeout` sets how long the node should wait, in whole milliseconds. Leave it at
+`0` to omit the parameter so the node applies its own default. EIP-7966 recommends 2
+seconds; bor defaults to 20 seconds (`--rpc.txsync.defaulttimeout`) and silently clamps
+anything above `--rpc.txsync.maxtimeout`, 1 minute by default, rather than rejecting it.
+
+The value goes on the wire as a hex quantity, because bor takes the parameter as
+`*hexutil.Uint64`, which unmarshals only from a quoted hex string and rejects a bare JSON
+number. EIP-7966 describes the parameter as an integer instead, and servers implementing it
+literally reject the hex form, so `--sync-tx-timeout-int` switches encodings. Against bor,
+leave it off.
+
+**This changes what the latency numbers mean.** Every other send path measures time to
+*accept* a transaction; with `--sync-txs` the recorded request duration is time to
+*receipt*. Because each request now blocks for the life of the transaction, `--concurrency`
+becomes the number of transactions in flight rather than the number of submissions per
+moment, and you will need a much higher value to reach the same send rate.
+
+At the end of a run the sync tracker logs a summary:
+
+- `receipts`, split into `speculative` and `canonical`
+- `reverted` and `no_status` for receipts that came back unsuccessful or without a status
+- `timeouts`, `queued`, `nonce_gaps` — EIP-7966 error codes 4, 5 and 6. A timeout means the
+  transaction reached the mempool but produced no receipt in time; it may still be mined
+  afterwards. A nonce gap carries the node's expected nonce in the error data.
+- `rejected` — the transaction was refused before the wait began
+- `p50_ms`, `p90_ms`, `p99_ms` of the synchronous call
+
+Bor implements only code 4 of that set. A transaction it refuses to accept fails before the
+wait starts and comes back with bor's own codes, which are counted too: `-38011`
+(nonce too high) as a nonce gap, and `-38010` (nonce too low), `-38013` (intrinsic gas),
+`-38014` (insufficient funds) and `-38026` (client limit exceeded) as `rejected`.
+
+The speculative/canonical split comes from the receipt itself where possible. Bor's
+preconfirmation pipeline marks a preconfirmed receipt with `"preconfirmation": true` and
+leaves its `blockHash` null, and that marker is taken as authoritative. EIP-7966 defines no
+such field, so for any other node the split falls back to reading the block fields: a
+receipt with no block cannot be canonical. A node that both omits the marker and fills in a
+speculative block number is indistinguishable from one answering canonically. To confirm
+canonical inclusion independently, combine with `--wait-for-receipt`, which polls for the
+receipt after the synchronous call returns — that pairing measures the speculative receipt
+and the canonical one separately.
+
+Note that stock bor without preconfirmations enabled only ever returns canonical receipts:
+it waits on chain events and requires both a block number and a block hash before
+answering, so `speculative` stays at zero. The speculative path needs bor's
+preconfirmation pipeline (`SubmitTxForPreconf` and the preconfirmation receipt index).
+
+Like `--private-txs`, `--sync-txs` is only supported by `transaction`, `blob`,
+`contract-call`, and `recall`, and the two flags are mutually exclusive.
+
+[eip-7966]: https://eips.ethereum.org/EIPS/eip-7966
+
 ### Gas Manager
 
 The loadtest command includes an optional gas manager for controlling transaction gas limits and pricing. Enable it with `--gas-manager-enabled`, then use the `--gas-manager-*` flags to:

--- a/cmd/loadtest/loadtestUsage.md
+++ b/cmd/loadtest/loadtestUsage.md
@@ -127,17 +127,40 @@ preconfirmation pipeline (`SubmitTxForPreconf` and the preconfirmation receipt i
 
 At verbosity 700 (trace) each synchronous submission is also logged individually: the
 node's raw receipt verbatim as JSON on success, or the RPC error with its code and data on
-failure. Pair with `--log-format json` for machine-parseable lines that can be checked for
+failure. Pair with `--pretty-logs=false` for machine-parseable lines that can be checked for
 correctness later, e.g. by diffing against `eth_getTransactionReceipt`:
 
 ```bash
-$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs -v 700 --log-format json
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs -v 700 --pretty-logs=false
 ```
 
 Like `--private-txs`, `--sync-txs` is only supported by `transaction`, `blob`,
 `contract-call`, and `recall`, and the two flags are mutually exclusive.
 
 [eip-7966]: https://eips.ethereum.org/EIPS/eip-7966
+
+### Waiting for Receipts
+
+`--wait-for-receipt` polls `eth_getTransactionReceipt` after each send, in the same
+goroutine that sent the transaction, so each worker blocks until its transaction is mined
+before sending the next one. By default polling uses exponential backoff with jitter,
+starting at `--receipt-retry-initial-delay-ms` and giving up after `--receipt-retry-max`
+attempts or one minute, whichever comes first.
+
+`--receipt-poll-interval` switches to polling at a fixed interval instead. In this mode
+`--receipt-retry-max` is ignored and polling is bounded only by the one-minute timeout.
+Backoff can overshoot the moment the receipt appeared by the length of the current backoff
+step, so a small fixed interval also makes the wait duration a usable receipt-latency
+measurement, at the cost of steadier RPC load:
+
+```bash
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --wait-for-receipt --receipt-poll-interval 50ms
+```
+
+At verbosity 700 (trace) each raw receipt is logged verbatim as JSON with the tx hash and
+the wait duration, the same shape as the `--sync-txs` receipt logs. Combined with
+`--sync-txs`, this logs the speculative receipt and the canonical one separately per
+transaction.
 
 ### Gas Manager
 

--- a/cmd/tail/tail.go
+++ b/cmd/tail/tail.go
@@ -96,13 +96,17 @@ var TailCmd = &cobra.Command{
 				}
 				log.Warn().Err(err).Msg("Unable to fetch latest block number; retrying")
 			} else if nextBlock <= latestBlock {
-				if err := writeBlockRange(ctx, ec, nextBlock, latestBlock); err != nil {
+				// Advance the cursor past whatever was printed, even on
+				// error, so a retry never re-prints blocks.
+				lastPrinted, printed, err := writeBlockRange(ctx, ec, nextBlock, latestBlock)
+				if printed {
+					nextBlock = lastPrinted + 1
+				}
+				if err != nil {
 					if !inputTail.Follow {
 						return err
 					}
 					log.Warn().Err(err).Msg("Unable to fetch block range; retrying")
-				} else {
-					nextBlock = latestBlock + 1
 				}
 			}
 
@@ -140,7 +144,11 @@ func getLatestBlockNumber(ctx context.Context, ec *ethrpc.Client) (uint64, error
 	return blockNumber, nil
 }
 
-func writeBlockRange(ctx context.Context, ec *ethrpc.Client, start, end uint64) error {
+// writeBlockRange fetches and prints blocks in [start, end]. It returns the
+// number of the last printed block and whether any block was printed so the
+// caller can advance its cursor past printed blocks even when an error is
+// returned, ensuring a retry never re-prints a block.
+func writeBlockRange(ctx context.Context, ec *ethrpc.Client, start, end uint64) (uint64, bool, error) {
 	blocks, err := util.GetBlockRangeInPages(
 		ctx,
 		start,
@@ -150,44 +158,69 @@ func writeBlockRange(ctx context.Context, ec *ethrpc.Client, start, end uint64) 
 		false,
 	)
 	if err != nil {
-		return err
+		return 0, false, err
+	}
+
+	type numberedBlock struct {
+		number uint64
+		raw    *json.RawMessage
+	}
+
+	// Batch responses are positional, so a null response at index i means the
+	// serving node does not have block start+i yet (e.g. a lagging node
+	// behind a load balancer). Printing stops before the first missing block
+	// so it can be retried instead of being skipped.
+	firstMissing := end + 1
+	parsed := make([]numberedBlock, 0, len(blocks))
+	for i, block := range blocks {
+		if block == nil || string(*block) == "null" {
+			if blockNum := start + uint64(i); blockNum < firstMissing {
+				firstMissing = blockNum
+			}
+			continue
+		}
+		blockNum, err := extractBlockNumber(block)
+		if err != nil {
+			return 0, false, fmt.Errorf("unable to parse block number: %w", err)
+		}
+		parsed = append(parsed, numberedBlock{number: blockNum, raw: block})
 	}
 
 	// Sort blocks by number to ensure correct order
-	sort.Slice(blocks, func(i, j int) bool {
-		numI, errI := extractBlockNumber(blocks[i])
-		numJ, errJ := extractBlockNumber(blocks[j])
-		if errI != nil || errJ != nil {
-			// If we can't parse, maintain original order
-			return i < j
-		}
-		return numI < numJ
+	sort.Slice(parsed, func(i, j int) bool {
+		return parsed[i].number < parsed[j].number
 	})
 
 	// Validate no gaps and output blocks
+	var lastPrinted uint64
+	printedAny := false
 	expectedBlock := start
-	for _, block := range blocks {
-		blockNum, err := extractBlockNumber(block)
-		if err != nil {
-			return fmt.Errorf("unable to parse block number: %w", err)
+	for _, block := range parsed {
+		if block.number >= firstMissing {
+			break
 		}
 
 		// Check for gaps. Continue anyway - the RPC may not have all
-		// blocks; expectedBlock is re-derived from blockNum below.
-		if blockNum > expectedBlock {
+		// blocks; expectedBlock is re-derived from block.number below.
+		if block.number > expectedBlock {
 			log.Warn().
 				Uint64("expected", expectedBlock).
-				Uint64("received", blockNum).
+				Uint64("received", block.number).
 				Msg("Gap detected in block sequence")
 		}
 
-		if _, err := fmt.Fprintln(os.Stdout, string(*block)); err != nil {
-			return err
+		if _, err := fmt.Fprintln(os.Stdout, string(*block.raw)); err != nil {
+			return lastPrinted, printedAny, err
 		}
-		expectedBlock = blockNum + 1
+		lastPrinted = block.number
+		printedAny = true
+		expectedBlock = block.number + 1
 	}
 
-	return nil
+	if firstMissing <= end {
+		return lastPrinted, printedAny, fmt.Errorf("block %d not yet available on serving node", firstMissing)
+	}
+	return lastPrinted, printedAny, nil
 }
 
 func extractBlockNumber(block *json.RawMessage) (uint64, error) {

--- a/doc/polycli_fund.md
+++ b/doc/polycli_fund.md
@@ -91,11 +91,13 @@ $ cast balance 0x5D8121cf716B70d3e345adB58157752304eED5C3
       --eth-amount big.Int             amount of wei to send to each wallet (default 50000000000000000)
   -f, --file string                    output JSON file path for storing addresses and private keys of funded wallets (default "wallets.json")
       --funder-address string          address of pre-deployed funder contract
+      --gas-price gas                  gas price with unit support (e.g., "100gwei", "1000000000")
       --hd-derivation                  derive wallets to fund from private key in deterministic way (default true)
   -h, --help                           help for fund
       --key-file string                file containing accounts private keys, one per line
       --multicall3-address string      address of pre-deployed multicall3 contract
   -n, --number uint                    number of wallets to fund (default 10)
+      --priority-gas-price gas         gas tip for EIP-1559 with unit support (e.g., "2gwei")
       --private-key string             hex encoded private key to use for sending transactions (default "0x42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
       --rate-limit float               requests per second limit (use negative value to remove limit) (default 4)
   -r, --rpc-url string                 RPC endpoint URL (default "http://localhost:8545")

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -87,6 +87,70 @@ $ polycli loadtest --rpc-url http://fullnode:8545 --send-rpc-url http://broadcas
 
 Like `--private-txs`, this flag is only supported by the modes that broadcast transactions explicitly: `transaction`, `blob`, `contract-call`, and `recall`.
 
+### Synchronous Sending (EIP-7966)
+
+`--sync-txs` broadcasts with [`eth_sendRawTransactionSync`][eip-7966] instead of
+`eth_sendRawTransaction`. That call does not return when the transaction is accepted; it
+returns when the node has a receipt for it, or fails when its timeout elapses. On a chain
+that preconfirms, the receipt can arrive well before canonical inclusion, which is what
+makes this useful for measuring preconfirmation latency.
+
+```bash
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs --concurrency 20
+```
+
+`--sync-tx-timeout` sets how long the node should wait, in whole milliseconds. Leave it at
+`0` to omit the parameter so the node applies its own default. EIP-7966 recommends 2
+seconds; bor defaults to 20 seconds (`--rpc.txsync.defaulttimeout`) and silently clamps
+anything above `--rpc.txsync.maxtimeout`, 1 minute by default, rather than rejecting it.
+
+The value goes on the wire as a hex quantity, because bor takes the parameter as
+`*hexutil.Uint64`, which unmarshals only from a quoted hex string and rejects a bare JSON
+number. EIP-7966 describes the parameter as an integer instead, and servers implementing it
+literally reject the hex form, so `--sync-tx-timeout-int` switches encodings. Against bor,
+leave it off.
+
+**This changes what the latency numbers mean.** Every other send path measures time to
+*accept* a transaction; with `--sync-txs` the recorded request duration is time to
+*receipt*. Because each request now blocks for the life of the transaction, `--concurrency`
+becomes the number of transactions in flight rather than the number of submissions per
+moment, and you will need a much higher value to reach the same send rate.
+
+At the end of a run the sync tracker logs a summary:
+
+- `receipts`, split into `speculative` and `canonical`
+- `reverted` and `no_status` for receipts that came back unsuccessful or without a status
+- `timeouts`, `queued`, `nonce_gaps` — EIP-7966 error codes 4, 5 and 6. A timeout means the
+  transaction reached the mempool but produced no receipt in time; it may still be mined
+  afterwards. A nonce gap carries the node's expected nonce in the error data.
+- `rejected` — the transaction was refused before the wait began
+- `p50_ms`, `p90_ms`, `p99_ms` of the synchronous call
+
+Bor implements only code 4 of that set. A transaction it refuses to accept fails before the
+wait starts and comes back with bor's own codes, which are counted too: `-38011`
+(nonce too high) as a nonce gap, and `-38010` (nonce too low), `-38013` (intrinsic gas),
+`-38014` (insufficient funds) and `-38026` (client limit exceeded) as `rejected`.
+
+The speculative/canonical split comes from the receipt itself where possible. Bor's
+preconfirmation pipeline marks a preconfirmed receipt with `"preconfirmation": true` and
+leaves its `blockHash` null, and that marker is taken as authoritative. EIP-7966 defines no
+such field, so for any other node the split falls back to reading the block fields: a
+receipt with no block cannot be canonical. A node that both omits the marker and fills in a
+speculative block number is indistinguishable from one answering canonically. To confirm
+canonical inclusion independently, combine with `--wait-for-receipt`, which polls for the
+receipt after the synchronous call returns — that pairing measures the speculative receipt
+and the canonical one separately.
+
+Note that stock bor without preconfirmations enabled only ever returns canonical receipts:
+it waits on chain events and requires both a block number and a block hash before
+answering, so `speculative` stays at zero. The speculative path needs bor's
+preconfirmation pipeline (`SubmitTxForPreconf` and the preconfirmation receipt index).
+
+Like `--private-txs`, `--sync-txs` is only supported by `transaction`, `blob`,
+`contract-call`, and `recall`, and the two flags are mutually exclusive.
+
+[eip-7966]: https://eips.ethereum.org/EIPS/eip-7966
+
 ### Gas Manager
 
 The loadtest command includes an optional gas manager for controlling transaction gas limits and pricing. Enable it with `--gas-manager-enabled`, then use the `--gas-manager-*` flags to:
@@ -205,6 +269,12 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --stop-on-insufficient-funds                       stop sending from account when it encounters insufficient funds error
       --store-data-size uint                             number of bytes to store in contract for store mode (default 1024)
       --summarize                                        produce execution summary after load test (can take a long time for large tests)
+      --sync-tx-timeout duration                         maximum time the node should wait for a receipt with --sync-txs, sent in whole
+                                                         milliseconds (0 omits the parameter so the node applies its own default)
+      --sync-tx-timeout-int                              send the --sync-tx-timeout value as a bare JSON integer instead of a hex quantity;
+                                                         bor wants hex (the default), while servers implementing EIP-7966 literally want an integer
+      --sync-txs                                         send transactions via eth_sendRawTransactionSync (EIP-7966), which blocks until
+                                                         the node has a receipt; useful for measuring preconfirmation latency
   -t, --time-limit int                                   maximum seconds to spend benchmarking (default: no limit) (default -1)
       --to-address string                                recipient address for transactions (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
       --wait-for-receipt                                 wait for transaction receipt to be mined instead of just sending

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -146,6 +146,15 @@ it waits on chain events and requires both a block number and a block hash befor
 answering, so `speculative` stays at zero. The speculative path needs bor's
 preconfirmation pipeline (`SubmitTxForPreconf` and the preconfirmation receipt index).
 
+At verbosity 700 (trace) each synchronous submission is also logged individually: the
+node's raw receipt verbatim as JSON on success, or the RPC error with its code and data on
+failure. Pair with `--log-format json` for machine-parseable lines that can be checked for
+correctness later, e.g. by diffing against `eth_getTransactionReceipt`:
+
+```bash
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs -v 700 --log-format json
+```
+
 Like `--private-txs`, `--sync-txs` is only supported by `transaction`, `blob`,
 `contract-call`, and `recall`, and the two flags are mutually exclusive.
 

--- a/doc/polycli_loadtest.md
+++ b/doc/polycli_loadtest.md
@@ -148,17 +148,40 @@ preconfirmation pipeline (`SubmitTxForPreconf` and the preconfirmation receipt i
 
 At verbosity 700 (trace) each synchronous submission is also logged individually: the
 node's raw receipt verbatim as JSON on success, or the RPC error with its code and data on
-failure. Pair with `--log-format json` for machine-parseable lines that can be checked for
+failure. Pair with `--pretty-logs=false` for machine-parseable lines that can be checked for
 correctness later, e.g. by diffing against `eth_getTransactionReceipt`:
 
 ```bash
-$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs -v 700 --log-format json
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --sync-txs -v 700 --pretty-logs=false
 ```
 
 Like `--private-txs`, `--sync-txs` is only supported by `transaction`, `blob`,
 `contract-call`, and `recall`, and the two flags are mutually exclusive.
 
 [eip-7966]: https://eips.ethereum.org/EIPS/eip-7966
+
+### Waiting for Receipts
+
+`--wait-for-receipt` polls `eth_getTransactionReceipt` after each send, in the same
+goroutine that sent the transaction, so each worker blocks until its transaction is mined
+before sending the next one. By default polling uses exponential backoff with jitter,
+starting at `--receipt-retry-initial-delay-ms` and giving up after `--receipt-retry-max`
+attempts or one minute, whichever comes first.
+
+`--receipt-poll-interval` switches to polling at a fixed interval instead. In this mode
+`--receipt-retry-max` is ignored and polling is bounded only by the one-minute timeout.
+Backoff can overshoot the moment the receipt appeared by the length of the current backoff
+step, so a small fixed interval also makes the wait duration a usable receipt-latency
+measurement, at the cost of steadier RPC load:
+
+```bash
+$ polycli loadtest --rpc-url http://localhost:8545 --mode t --wait-for-receipt --receipt-poll-interval 50ms
+```
+
+At verbosity 700 (trace) each raw receipt is logged verbatim as JSON with the tx hash and
+the wait duration, the same shape as the `--sync-txs` receipt logs. Combined with
+`--sync-txs`, this logs the speculative receipt and the canonical one separately per
+transaction.
 
 ### Gas Manager
 
@@ -262,6 +285,9 @@ The codebase has a contract that used for load testing. It's written in Solidity
       --rate-limit float                                 requests per second limit (use negative value to remove limit) (default 4)
       --rate-limit-ramp-duration duration                linearly ramp rate limit from max(1% of --rate-limit, 1 TPS) to full --rate-limit over this duration (e.g. 3m; 0 disables ramp)
       --recall-blocks uint                               number of blocks that we'll attempt to fetch for recall (default 50)
+      --receipt-poll-interval duration                   fixed interval between receipt polls with --wait-for-receipt; when set, polling is
+                                                         bounded only by the receipt timeout and --receipt-retry-max is ignored (0 uses
+                                                         exponential backoff with jitter)
       --receipt-retry-initial-delay-ms uint              initial delay in milliseconds for receipt polling (uses exponential backoff with jitter) (default 100)
       --receipt-retry-max uint                           maximum polling attempts for transaction receipt with --wait-for-receipt (default 30)
       --refund-remaining-funds                           refund remaining balance to funding account after completion

--- a/doc/polycli_loadtest_uniswapv3.md
+++ b/doc/polycli_loadtest_uniswapv3.md
@@ -124,6 +124,12 @@ The command also inherits flags from parent commands.
       --send-rpc-url string                              secondary RPC endpoint used only to broadcast transactions (eth_sendRawTransaction / eth_sendRawTransactionPrivate); all other calls use --rpc-url
       --stop-on-insufficient-funds                       stop sending from account when it encounters insufficient funds error
       --summarize                                        produce execution summary after load test (can take a long time for large tests)
+      --sync-tx-timeout duration                         maximum time the node should wait for a receipt with --sync-txs, sent in whole
+                                                         milliseconds (0 omits the parameter so the node applies its own default)
+      --sync-tx-timeout-int                              send the --sync-tx-timeout value as a bare JSON integer instead of a hex quantity;
+                                                         bor wants hex (the default), while servers implementing EIP-7966 literally want an integer
+      --sync-txs                                         send transactions via eth_sendRawTransactionSync (EIP-7966), which blocks until
+                                                         the node has a receipt; useful for measuring preconfirmation latency
   -t, --time-limit int                                   maximum seconds to spend benchmarking (default: no limit) (default -1)
       --to-address string                                recipient address for transactions (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
   -v, --verbosity string                                 log level (string or int):

--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -67,6 +67,9 @@ type Config struct {
 	ReceiptRetryDelay  uint // initial delay in milliseconds
 	OutputRawTxOnly    bool
 	PrivateTxs         bool
+	SyncTxs            bool
+	SyncTxTimeout      time.Duration
+	SyncTxTimeoutInt   bool
 	StartNonce         uint64
 	StartNonceSet      bool `json:"-"`
 	GasPriceMultiplier float64
@@ -227,6 +230,27 @@ func (c *Config) Validate() error {
 		if err := c.validateModesSupportRawSend("--private-txs"); err != nil {
 			return err
 		}
+	}
+
+	if c.SyncTxs {
+		if c.PrivateTxs {
+			return errors.New("--sync-txs and --private-txs are mutually exclusive (each sends via a different RPC method)")
+		}
+		if c.EthCallOnly {
+			return errors.New("--sync-txs doesn't make sense with --eth-call-only, which never sends a transaction")
+		}
+		if c.OutputRawTxOnly {
+			return errors.New("--sync-txs doesn't make sense with --output-raw-tx-only, which never sends a transaction")
+		}
+		if err := c.validateModesSupportRawSend("--sync-txs"); err != nil {
+			return err
+		}
+	}
+	if c.SyncTxTimeout < 0 {
+		return fmt.Errorf("--sync-tx-timeout must not be negative, got %s", c.SyncTxTimeout)
+	}
+	if c.SyncTxTimeout > 0 && c.SyncTxTimeout < time.Millisecond {
+		return fmt.Errorf("--sync-tx-timeout is sent in whole milliseconds, so %s rounds to zero; use 0 to let the node apply its default", c.SyncTxTimeout)
 	}
 
 	if c.SendRPCURL != "" {

--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -246,6 +246,7 @@ func (c *Config) Validate() error {
 			return err
 		}
 	}
+
 	if c.SyncTxTimeout < 0 {
 		return fmt.Errorf("--sync-tx-timeout must not be negative, got %s", c.SyncTxTimeout)
 	}

--- a/loadtest/config/config.go
+++ b/loadtest/config/config.go
@@ -54,27 +54,28 @@ type Config struct {
 	Seed        int64
 
 	// Transaction options
-	PrivateKey         string
-	ToAddress          string
-	EthAmountInWei     uint64
-	RandomRecipients   bool
-	LegacyTxMode       bool
-	FireAndForget      bool
-	CheckForPreconf    bool
-	PreconfStatsFile   string
-	WaitForReceipt     bool
-	ReceiptRetryMax    uint
-	ReceiptRetryDelay  uint // initial delay in milliseconds
-	OutputRawTxOnly    bool
-	PrivateTxs         bool
-	SyncTxs            bool
-	SyncTxTimeout      time.Duration
-	SyncTxTimeoutInt   bool
-	StartNonce         uint64
-	StartNonceSet      bool `json:"-"`
-	GasPriceMultiplier float64
-	DuplicateNonceRate float64
-	ReverseNonceOrder  bool
+	PrivateKey          string
+	ToAddress           string
+	EthAmountInWei      uint64
+	RandomRecipients    bool
+	LegacyTxMode        bool
+	FireAndForget       bool
+	CheckForPreconf     bool
+	PreconfStatsFile    string
+	WaitForReceipt      bool
+	ReceiptRetryMax     uint
+	ReceiptRetryDelay   uint // initial delay in milliseconds
+	ReceiptPollInterval time.Duration
+	OutputRawTxOnly     bool
+	PrivateTxs          bool
+	SyncTxs             bool
+	SyncTxTimeout       time.Duration
+	SyncTxTimeoutInt    bool
+	StartNonce          uint64
+	StartNonceSet       bool `json:"-"`
+	GasPriceMultiplier  float64
+	DuplicateNonceRate  float64
+	ReverseNonceOrder   bool
 
 	// Gas options
 	ForceGasLimit         uint64
@@ -197,8 +198,17 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("the backoff factor needs to be non-zero positive. Given: %f", c.AdaptiveBackoffFactor)
 	}
 
-	if c.WaitForReceipt && c.ReceiptRetryMax <= 1 {
+	// Retry max only governs the exponential backoff schedule; fixed-interval
+	// polling is bounded by the receipt timeout instead.
+	if c.WaitForReceipt && c.ReceiptPollInterval == 0 && c.ReceiptRetryMax <= 1 {
 		return errors.New("when waiting for a receipt, use a max retry greater than 1")
+	}
+
+	if c.ReceiptPollInterval < 0 {
+		return fmt.Errorf("--receipt-poll-interval must not be negative, got %s", c.ReceiptPollInterval)
+	}
+	if c.ReceiptPollInterval > 0 && !c.WaitForReceipt {
+		return errors.New("--receipt-poll-interval requires --wait-for-receipt")
 	}
 
 	if c.EthCallOnly {

--- a/loadtest/config/config_test.go
+++ b/loadtest/config/config_test.go
@@ -229,3 +229,95 @@ func TestValidateReverseNonceOrder(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSyncTxs(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:   "sync txs alone",
+			mutate: func(c *Config) { c.SyncTxs = true },
+		},
+		{
+			name: "sync txs with timeout",
+			mutate: func(c *Config) {
+				c.SyncTxs = true
+				c.SyncTxTimeout = 2 * time.Second
+			},
+		},
+		{
+			name: "sync and private are exclusive",
+			mutate: func(c *Config) {
+				c.SyncTxs = true
+				c.PrivateTxs = true
+			},
+			wantErr: "--sync-txs and --private-txs are mutually exclusive",
+		},
+		{
+			name: "sync with call only",
+			mutate: func(c *Config) {
+				c.SyncTxs = true
+				c.EthCallOnly = true
+			},
+			wantErr: "--sync-txs doesn't make sense with --eth-call-only",
+		},
+		{
+			name: "sync with raw output",
+			mutate: func(c *Config) {
+				c.SyncTxs = true
+				c.OutputRawTxOnly = true
+			},
+			wantErr: "--sync-txs doesn't make sense with --output-raw-tx-only",
+		},
+		{
+			name: "sync with an unsupported mode",
+			mutate: func(c *Config) {
+				c.SyncTxs = true
+				c.Modes = []string{"d"}
+			},
+			wantErr: "--sync-txs is not supported for mode \"d\"",
+		},
+		{
+			name:    "negative timeout",
+			mutate:  func(c *Config) { c.SyncTxTimeout = -time.Second },
+			wantErr: "--sync-tx-timeout must not be negative",
+		},
+		{
+			name:    "sub-millisecond timeout rounds to zero",
+			mutate:  func(c *Config) { c.SyncTxTimeout = 500 * time.Microsecond },
+			wantErr: "rounds to zero",
+		},
+		{
+			// The pairing that measures speculative then canonical inclusion.
+			name: "sync with wait for receipt",
+			mutate: func(c *Config) {
+				c.SyncTxs = true
+				c.WaitForReceipt = true
+				c.ReceiptRetryMax = 30
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validConfig()
+			tt.mutate(c)
+
+			err := c.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Validate() = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/loadtest/config/config_test.go
+++ b/loadtest/config/config_test.go
@@ -321,3 +321,66 @@ func TestValidateSyncTxs(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateReceiptPollInterval(t *testing.T) {
+	tests := []struct {
+		name            string
+		waitForReceipt  bool
+		pollInterval    time.Duration
+		receiptRetryMax uint
+		wantErr         string
+	}{
+		{
+			name:            "backoff mode still requires retry max",
+			waitForReceipt:  true,
+			receiptRetryMax: 1,
+			wantErr:         "use a max retry greater than 1",
+		},
+		{
+			name:            "interval mode ignores retry max",
+			waitForReceipt:  true,
+			pollInterval:    50 * time.Millisecond,
+			receiptRetryMax: 1,
+		},
+		{
+			name:           "negative interval",
+			waitForReceipt: true,
+			pollInterval:   -time.Second,
+			wantErr:        "--receipt-poll-interval must not be negative",
+		},
+		{
+			name:         "interval requires wait-for-receipt",
+			pollInterval: 50 * time.Millisecond,
+			wantErr:      "--receipt-poll-interval requires --wait-for-receipt",
+		},
+		{
+			name:            "valid interval",
+			waitForReceipt:  true,
+			pollInterval:    50 * time.Millisecond,
+			receiptRetryMax: 30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := validConfig()
+			cfg.WaitForReceipt = tt.waitForReceipt
+			cfg.ReceiptPollInterval = tt.pollInterval
+			cfg.ReceiptRetryMax = tt.receiptRetryMax
+
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/loadtest/mode/dependencies.go
+++ b/loadtest/mode/dependencies.go
@@ -33,6 +33,10 @@ type Dependencies struct {
 	ERC721Contract     *tokens.ERC721
 	ERC721Address      common.Address
 
+	// SyncTracker aggregates eth_sendRawTransactionSync outcomes when
+	// --sync-txs is set. Nil otherwise, which records nothing.
+	SyncTracker *SyncTracker
+
 	// Mode-specific data
 	RecallTransactions []rpctypes.PolyTransaction
 	IndexedActivity    *IndexedActivity

--- a/loadtest/mode/synctx.go
+++ b/loadtest/mode/synctx.go
@@ -142,17 +142,19 @@ func SendRawTransactionSync(ctx context.Context, deps *Dependencies, cfg *config
 		}
 	}
 
-	logSyncOutcome(tx.Hash(), raw, elapsed, err)
+	LogReceiptTrace(tx.Hash(), raw, elapsed, err,
+		"Sync transaction receipt", "Sync transaction submission failed")
 
 	deps.SyncTracker.Record(tx.Hash(), receipt, elapsed, err)
 
 	return err
 }
 
-// logSyncOutcome trace-logs the raw receipt (or the RPC error) of one
-// synchronous submission so the node's answers can be audited later, e.g. by
-// diffing them against eth_getTransactionReceipt.
-func logSyncOutcome(txHash common.Hash, raw json.RawMessage, elapsed time.Duration, err error) {
+// LogReceiptTrace trace-logs a raw receipt (or the error that stood in for
+// one) so the node's answers can be audited later, e.g. by diffing them
+// against eth_getTransactionReceipt. It is shared by the synchronous send path
+// and the runner's --wait-for-receipt polling, which differ only in message.
+func LogReceiptTrace(txHash common.Hash, raw json.RawMessage, elapsed time.Duration, err error, okMsg, failMsg string) {
 	if zerolog.GlobalLevel() > zerolog.TraceLevel {
 		return
 	}
@@ -174,7 +176,7 @@ func logSyncOutcome(txHash common.Hash, raw json.RawMessage, elapsed time.Durati
 		if len(raw) > 0 {
 			event = event.Str("rawResult", string(raw))
 		}
-		event.Msg("Sync transaction submission failed")
+		event.Msg(failMsg)
 		return
 	}
 
@@ -185,7 +187,7 @@ func logSyncOutcome(txHash common.Hash, raw json.RawMessage, elapsed time.Durati
 		Str("txHash", txHash.Hex()).
 		Int64("durationMs", elapsed.Milliseconds()).
 		RawJSON("receipt", raw).
-		Msg("Sync transaction receipt")
+		Msg(okMsg)
 }
 
 // SyncErrorCode returns the EIP-7966 error code carried by an

--- a/loadtest/mode/synctx.go
+++ b/loadtest/mode/synctx.go
@@ -2,6 +2,7 @@ package mode
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -13,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
 	"github.com/montanaflynn/stats"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
 	"github.com/0xPolygon/polygon-cli/loadtest/config"
@@ -126,14 +128,64 @@ func SendRawTransactionSync(ctx context.Context, deps *Dependencies, cfg *config
 		}
 	}
 
-	var receipt *SyncReceipt
+	// Decode into raw JSON first so the receipt can be logged verbatim; the
+	// SyncReceipt only models the handful of fields the tracker classifies on.
+	var raw json.RawMessage
 	start := time.Now()
-	err = deps.SendRPCClient.CallContext(ctx, &receipt, "eth_sendRawTransactionSync", params...)
+	err = deps.SendRPCClient.CallContext(ctx, &raw, "eth_sendRawTransactionSync", params...)
 	elapsed := time.Since(start)
+
+	var receipt *SyncReceipt
+	if err == nil && len(raw) > 0 {
+		if uErr := json.Unmarshal(raw, &receipt); uErr != nil {
+			err = fmt.Errorf("failed to decode sync receipt: %w", uErr)
+		}
+	}
+
+	logSyncOutcome(tx.Hash(), raw, elapsed, err)
 
 	deps.SyncTracker.Record(tx.Hash(), receipt, elapsed, err)
 
 	return err
+}
+
+// logSyncOutcome trace-logs the raw receipt (or the RPC error) of one
+// synchronous submission so the node's answers can be audited later, e.g. by
+// diffing them against eth_getTransactionReceipt.
+func logSyncOutcome(txHash common.Hash, raw json.RawMessage, elapsed time.Duration, err error) {
+	if zerolog.GlobalLevel() > zerolog.TraceLevel {
+		return
+	}
+
+	if err != nil {
+		event := log.Trace().
+			Str("txHash", txHash.Hex()).
+			Int64("durationMs", elapsed.Milliseconds()).
+			Err(err)
+		if code, ok := SyncErrorCode(err); ok {
+			event = event.Int("errorCode", code)
+		}
+		var dataErr ethrpc.DataError
+		if errors.As(err, &dataErr) {
+			event = event.Any("errorData", dataErr.ErrorData())
+		}
+		// Raw is only non-empty here when the result failed to decode; log it
+		// as a string since it may not be valid JSON.
+		if len(raw) > 0 {
+			event = event.Str("rawResult", string(raw))
+		}
+		event.Msg("Sync transaction submission failed")
+		return
+	}
+
+	if len(raw) == 0 {
+		raw = json.RawMessage("null")
+	}
+	log.Trace().
+		Str("txHash", txHash.Hex()).
+		Int64("durationMs", elapsed.Milliseconds()).
+		RawJSON("receipt", raw).
+		Msg("Sync transaction receipt")
 }
 
 // SyncErrorCode returns the EIP-7966 error code carried by an

--- a/loadtest/mode/synctx.go
+++ b/loadtest/mode/synctx.go
@@ -236,7 +236,11 @@ func (t *SyncTracker) Record(txHash common.Hash, receipt *SyncReceipt, elapsed t
 		t.speculative.Add(1)
 	} else {
 		t.canonical.Add(1)
-		result.BlockNumber = receipt.BlockNumber.ToInt().Uint64()
+		// A node can call a receipt canonical with the marker while leaving the
+		// block fields out, so this stays guarded.
+		if receipt.BlockNumber != nil {
+			result.BlockNumber = receipt.BlockNumber.ToInt().Uint64()
+		}
 	}
 	if receipt.GasUsed != nil {
 		result.GasUsed = uint64(*receipt.GasUsed)
@@ -277,8 +281,9 @@ func (t *SyncTracker) Stats() {
 		return
 	}
 
-	var durations []float64
-	for _, r := range t.Results() {
+	results := t.Results()
+	durations := make([]float64, 0, len(results))
+	for _, r := range results {
 		durations = append(durations, float64(r.DurationMs))
 	}
 	pct := func(p float64) float64 {

--- a/loadtest/mode/synctx.go
+++ b/loadtest/mode/synctx.go
@@ -1,0 +1,308 @@
+package mode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/montanaflynn/stats"
+	"github.com/rs/zerolog/log"
+
+	"github.com/0xPolygon/polygon-cli/loadtest/config"
+)
+
+// EIP-7966 error codes returned by eth_sendRawTransactionSync. These are
+// method-specific codes, not the standard JSON-RPC ones, and each carries a
+// data field: the transaction hash for timeout and queued, the expected nonce
+// for a nonce gap.
+const (
+	// SyncErrTimeout means the transaction reached the mempool but no receipt
+	// was produced before the timeout elapsed. The transaction may still be
+	// mined afterwards.
+	SyncErrTimeout = 4
+	// SyncErrQueued means the transaction was not added to the mempool because
+	// it is not ready for execution.
+	SyncErrQueued = 5
+	// SyncErrNonceGap means the transaction was not added to the mempool
+	// because of a nonce gap. The error data carries the expected nonce.
+	SyncErrNonceGap = 6
+)
+
+// Codes bor returns from this method beyond the EIP-7966 set. Bor implements
+// only code 4 from the EIP; a transaction it refuses to accept fails in
+// SubmitTransaction first and comes back with one of these instead, so they are
+// classified separately rather than lumped in with unknown errors.
+const (
+	SyncErrBorNonceTooLow       = -38010
+	SyncErrBorNonceTooHigh      = -38011
+	SyncErrBorIntrinsicGas      = -38013
+	SyncErrBorInsufficientFunds = -38014
+	SyncErrBorClientLimit       = -38026
+)
+
+// SyncReceipt is the receipt returned by eth_sendRawTransactionSync. EIP-7966
+// specifies "the transaction receipt object as defined by the
+// eth_getTransactionReceipt method", but a node answering before canonical
+// inclusion may leave the block fields empty, so every field is optional here
+// rather than decoded into types.Receipt, which requires them.
+type SyncReceipt struct {
+	TransactionHash common.Hash     `json:"transactionHash"`
+	Status          *hexutil.Uint64 `json:"status"`
+	GasUsed         *hexutil.Uint64 `json:"gasUsed"`
+	BlockNumber     *hexutil.Big    `json:"blockNumber"`
+	BlockHash       *common.Hash    `json:"blockHash"`
+
+	// Preconfirmation is bor's marker for a receipt produced by its
+	// preconfirmation pipeline rather than canonical block import. It is not
+	// part of EIP-7966, so nodes that do not preconfirm simply omit it.
+	Preconfirmation *bool `json:"preconfirmation"`
+}
+
+// Speculative reports whether the receipt is a preconfirmation rather than a
+// canonical one.
+//
+// Bor states this outright with a "preconfirmation" field, and that answer is
+// taken when present. EIP-7966 itself defines no such marker, so for every
+// other node this falls back to reading the block fields: bor's preconfirmation
+// receipts carry no block hash, and a receipt with no block cannot be canonical
+// on any implementation. A node that both omits the marker and fills in a
+// speculative block number is indistinguishable from one answering canonically;
+// pair with --wait-for-receipt to confirm canonical inclusion independently.
+func (r *SyncReceipt) Speculative() bool {
+	if r == nil {
+		return false
+	}
+	if r.Preconfirmation != nil {
+		return *r.Preconfirmation
+	}
+	if r.BlockNumber == nil || r.BlockNumber.ToInt().Sign() == 0 {
+		return true
+	}
+	return r.BlockHash == nil || *r.BlockHash == (common.Hash{})
+}
+
+// Succeeded reports whether the receipt carries a success status. A receipt
+// with no status field at all is not treated as a success.
+func (r *SyncReceipt) Succeeded() bool {
+	return r != nil && r.Status != nil && uint64(*r.Status) == types.ReceiptStatusSuccessful
+}
+
+// SendRawTransactionSync submits a signed transaction with
+// eth_sendRawTransactionSync (EIP-7966), which returns once the node has a
+// receipt for it or the timeout elapses, and records the outcome on
+// deps.SyncTracker when one is set.
+//
+// The returned error is the RPC error verbatim, so the caller records the same
+// failure the node reported. Note that a timeout is an error even though the
+// transaction is in the mempool and may still be mined.
+func SendRawTransactionSync(ctx context.Context, deps *Dependencies, cfg *config.Config, tx *types.Transaction) error {
+	rawTx, err := tx.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal transaction: %w", err)
+	}
+
+	// Omit the timeout entirely when unset so the node applies its own default
+	// (EIP-7966 recommends 2s; bor defaults to 20s and clamps anything above
+	// its --rpc.txsync.maxtimeout instead of rejecting it).
+	//
+	// Encoding: bor takes this parameter as *hexutil.Uint64, which unmarshals
+	// only from a quoted hex quantity and rejects a bare JSON number, so hex is
+	// the default. EIP-7966 describes the parameter as an integer and
+	// spec-literal servers reject the hex form, hence --sync-tx-timeout-int.
+	params := []any{hexutil.Encode(rawTx)}
+	if timeout := cfg.SyncTxTimeout; timeout > 0 {
+		ms := uint64(timeout.Milliseconds())
+		if cfg.SyncTxTimeoutInt {
+			params = append(params, ms)
+		} else {
+			params = append(params, hexutil.Uint64(ms))
+		}
+	}
+
+	var receipt *SyncReceipt
+	start := time.Now()
+	err = deps.SendRPCClient.CallContext(ctx, &receipt, "eth_sendRawTransactionSync", params...)
+	elapsed := time.Since(start)
+
+	deps.SyncTracker.Record(tx.Hash(), receipt, elapsed, err)
+
+	return err
+}
+
+// SyncErrorCode returns the EIP-7966 error code carried by an
+// eth_sendRawTransactionSync failure, and whether the error had one at all.
+func SyncErrorCode(err error) (int, bool) {
+	var rpcErr ethrpc.Error
+	if errors.As(err, &rpcErr) {
+		return rpcErr.ErrorCode(), true
+	}
+	return 0, false
+}
+
+// SyncTxResult holds the outcome of a single synchronous submission.
+type SyncTxResult struct {
+	TxHash      string `json:"tx_hash"`
+	DurationMs  int64  `json:"duration_ms"`
+	Speculative bool   `json:"speculative,omitempty"`
+	BlockNumber uint64 `json:"block_number,omitempty"`
+	GasUsed     uint64 `json:"gas_used,omitempty"`
+	Status      uint64 `json:"status,omitempty"`
+	ErrorCode   int    `json:"error_code,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
+// SyncTracker aggregates eth_sendRawTransactionSync outcomes across routines.
+// A nil tracker records nothing, so callers never need to check for one.
+type SyncTracker struct {
+	submitted   atomic.Uint64
+	receipts    atomic.Uint64
+	speculative atomic.Uint64
+	canonical   atomic.Uint64
+	reverted    atomic.Uint64
+	noStatus    atomic.Uint64
+
+	timeouts  atomic.Uint64
+	queued    atomic.Uint64
+	nonceGaps atomic.Uint64
+	rejected  atomic.Uint64
+	otherErrs atomic.Uint64
+
+	mu      sync.Mutex
+	results []SyncTxResult
+}
+
+// NewSyncTracker creates a tracker for synchronous submission outcomes.
+func NewSyncTracker() *SyncTracker {
+	return &SyncTracker{results: make([]SyncTxResult, 0, 1024)}
+}
+
+// Record files the outcome of one submission.
+func (t *SyncTracker) Record(txHash common.Hash, receipt *SyncReceipt, elapsed time.Duration, err error) {
+	if t == nil {
+		return
+	}
+
+	t.submitted.Add(1)
+
+	result := SyncTxResult{
+		TxHash:     txHash.Hex(),
+		DurationMs: elapsed.Milliseconds(),
+	}
+
+	if err != nil {
+		result.Error = err.Error()
+		if code, ok := SyncErrorCode(err); ok {
+			result.ErrorCode = code
+			switch code {
+			case SyncErrTimeout:
+				t.timeouts.Add(1)
+			case SyncErrQueued:
+				t.queued.Add(1)
+			case SyncErrNonceGap, SyncErrBorNonceTooHigh:
+				t.nonceGaps.Add(1)
+			case SyncErrBorNonceTooLow, SyncErrBorIntrinsicGas,
+				SyncErrBorInsufficientFunds, SyncErrBorClientLimit:
+				// Refused before the wait even started.
+				t.rejected.Add(1)
+			default:
+				t.otherErrs.Add(1)
+			}
+		} else {
+			t.otherErrs.Add(1)
+		}
+
+		t.append(result)
+		return
+	}
+
+	if receipt == nil {
+		// No error and no receipt: the node answered, but with nothing usable.
+		t.otherErrs.Add(1)
+		result.Error = "empty receipt"
+		t.append(result)
+		return
+	}
+
+	t.receipts.Add(1)
+	result.Speculative = receipt.Speculative()
+	if result.Speculative {
+		t.speculative.Add(1)
+	} else {
+		t.canonical.Add(1)
+		result.BlockNumber = receipt.BlockNumber.ToInt().Uint64()
+	}
+	if receipt.GasUsed != nil {
+		result.GasUsed = uint64(*receipt.GasUsed)
+	}
+	switch {
+	case receipt.Status == nil:
+		t.noStatus.Add(1)
+	case receipt.Succeeded():
+		result.Status = types.ReceiptStatusSuccessful
+	default:
+		t.reverted.Add(1)
+	}
+
+	t.append(result)
+}
+
+func (t *SyncTracker) append(result SyncTxResult) {
+	t.mu.Lock()
+	t.results = append(t.results, result)
+	t.mu.Unlock()
+}
+
+// Results returns a copy of the per-transaction outcomes.
+func (t *SyncTracker) Results() []SyncTxResult {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]SyncTxResult, len(t.results))
+	copy(out, t.results)
+	return out
+}
+
+// Stats logs a summary of the synchronous submissions.
+func (t *SyncTracker) Stats() {
+	if t == nil || t.submitted.Load() == 0 {
+		return
+	}
+
+	var durations []float64
+	for _, r := range t.Results() {
+		durations = append(durations, float64(r.DurationMs))
+	}
+	pct := func(p float64) float64 {
+		v, err := stats.Percentile(durations, p)
+		if err != nil {
+			return 0
+		}
+		return v
+	}
+
+	log.Info().
+		Uint64("submitted", t.submitted.Load()).
+		Uint64("receipts", t.receipts.Load()).
+		Uint64("speculative", t.speculative.Load()).
+		Uint64("canonical", t.canonical.Load()).
+		Uint64("reverted", t.reverted.Load()).
+		Uint64("no_status", t.noStatus.Load()).
+		Uint64("timeouts", t.timeouts.Load()).
+		Uint64("queued", t.queued.Load()).
+		Uint64("nonce_gaps", t.nonceGaps.Load()).
+		Uint64("rejected", t.rejected.Load()).
+		Uint64("other_errors", t.otherErrs.Load()).
+		Float64("p50_ms", pct(50)).
+		Float64("p90_ms", pct(90)).
+		Float64("p99_ms", pct(99)).
+		Msg("Synchronous transaction submission stats")
+}

--- a/loadtest/mode/synctx_test.go
+++ b/loadtest/mode/synctx_test.go
@@ -1,0 +1,518 @@
+package mode
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
+
+	"github.com/0xPolygon/polygon-cli/loadtest/config"
+)
+
+// syncRPC is a fake JSON-RPC endpoint standing in for a node implementing
+// eth_sendRawTransactionSync. It records the params it was called with so the
+// wire format can be asserted, and replies with a canned result or error.
+type syncRPC struct {
+	t *testing.T
+
+	// result is marshalled as the JSON-RPC result when err is nil.
+	result any
+	// errCode/errMsg/errData produce a JSON-RPC error response instead.
+	errCode int
+	errMsg  string
+	errData any
+
+	mu     sync.Mutex
+	params []any
+	calls  int
+}
+
+func newSyncRPC(t *testing.T, s *syncRPC) *ethrpc.Client {
+	t.Helper()
+	s.t = t
+	server := httptest.NewServer(http.HandlerFunc(s.handle))
+	t.Cleanup(server.Close)
+
+	client, err := ethrpc.DialContext(t.Context(), server.URL)
+	if err != nil {
+		t.Fatalf("failed to dial fake rpc: %v", err)
+	}
+	t.Cleanup(client.Close)
+	return client
+}
+
+func (s *syncRPC) handle(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+		Params []any           `json:"params"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Method != "eth_sendRawTransactionSync" {
+		http.Error(w, "unexpected method "+req.Method, http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.params = req.Params
+	s.calls++
+	s.mu.Unlock()
+
+	var payload []byte
+	var err error
+	if s.errCode != 0 {
+		body := map[string]any{"code": s.errCode, "message": s.errMsg}
+		if s.errData != nil {
+			body["data"] = s.errData
+		}
+		payload, err = json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": json.RawMessage(req.ID), "error": body,
+		})
+	} else {
+		payload, err = json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": json.RawMessage(req.ID), "result": s.result,
+		})
+	}
+	if err != nil {
+		s.t.Errorf("failed to marshal rpc response: %v", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, werr := w.Write(payload); werr != nil {
+		s.t.Errorf("failed to write rpc response: %v", werr)
+	}
+}
+
+func (s *syncRPC) lastParams() []any {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.params
+}
+
+// testTx returns a signed transaction to submit.
+func testTx(t *testing.T) *types.Transaction {
+	t.Helper()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	signer := types.LatestSignerForChainID(big.NewInt(1337))
+	tx, err := types.SignNewTx(key, signer, &types.DynamicFeeTx{
+		ChainID:   big.NewInt(1337),
+		Nonce:     7,
+		GasTipCap: big.NewInt(1e9),
+		GasFeeCap: big.NewInt(2e9),
+		Gas:       21000,
+		To:        &common.Address{},
+	})
+	if err != nil {
+		t.Fatalf("failed to sign tx: %v", err)
+	}
+	return tx
+}
+
+// canonicalReceipt is a receipt with the block fields filled in.
+func canonicalReceipt(hash common.Hash) map[string]any {
+	return map[string]any{
+		"transactionHash": hash.Hex(),
+		"status":          "0x1",
+		"gasUsed":         "0x5208",
+		"blockNumber":     "0x2a",
+		"blockHash":       common.HexToHash("0xbeef").Hex(),
+	}
+}
+
+// speculativeReceipt is a receipt a preconfirming node can return before the
+// transaction lands in a canonical block.
+func speculativeReceipt(hash common.Hash) map[string]any {
+	return map[string]any{
+		"transactionHash": hash.Hex(),
+		"status":          "0x1",
+		"gasUsed":         "0x5208",
+		"blockNumber":     nil,
+		"blockHash":       nil,
+	}
+}
+
+func send(t *testing.T, rpc *syncRPC, cfg *config.Config, tx *types.Transaction) (*SyncTracker, error) {
+	t.Helper()
+	client := newSyncRPC(t, rpc)
+	tracker := NewSyncTracker()
+	deps := &Dependencies{SendRPCClient: client, SyncTracker: tracker}
+	return tracker, SendRawTransactionSync(t.Context(), deps, cfg, tx)
+}
+
+func TestSendRawTransactionSyncOmitsUnsetTimeout(t *testing.T) {
+	tx := testTx(t)
+	rpc := &syncRPC{result: canonicalReceipt(tx.Hash())}
+
+	if _, err := send(t, rpc, &config.Config{}, tx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	params := rpc.lastParams()
+	if len(params) != 1 {
+		t.Fatalf("params = %v, want just the raw transaction", params)
+	}
+	raw, ok := params[0].(string)
+	if !ok || len(raw) < 4 || raw[:2] != "0x" {
+		t.Errorf("params[0] = %v, want a 0x-prefixed raw transaction", params[0])
+	}
+}
+
+func TestSendRawTransactionSyncSendsTimeoutAsHexByDefault(t *testing.T) {
+	// bor takes this parameter as *hexutil.Uint64, which unmarshals only from a
+	// quoted hex quantity and rejects a bare JSON number, so pin the encoding.
+	tx := testTx(t)
+	rpc := &syncRPC{result: canonicalReceipt(tx.Hash())}
+
+	if _, err := send(t, rpc, &config.Config{SyncTxTimeout: 5 * time.Second}, tx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	params := rpc.lastParams()
+	if len(params) != 2 {
+		t.Fatalf("params = %v, want raw transaction and timeout", params)
+	}
+	got, ok := params[1].(string)
+	if !ok {
+		t.Fatalf("params[1] = %#v (%T), want a hex quantity string", params[1], params[1])
+	}
+	if got != "0x1388" {
+		t.Errorf("timeout = %s, want 0x1388 (5000ms)", got)
+	}
+}
+
+func TestSendRawTransactionSyncSendsTimeoutAsIntegerWhenAsked(t *testing.T) {
+	// EIP-7966 describes the parameter as an integer, which spec-literal
+	// servers require and which hexutil.Uint64 rejects. --sync-tx-timeout-int
+	// selects it.
+	tx := testTx(t)
+	rpc := &syncRPC{result: canonicalReceipt(tx.Hash())}
+
+	cfg := &config.Config{SyncTxTimeout: 5 * time.Second, SyncTxTimeoutInt: true}
+	if _, err := send(t, rpc, cfg, tx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	params := rpc.lastParams()
+	if len(params) != 2 {
+		t.Fatalf("params = %v, want raw transaction and timeout", params)
+	}
+	// encoding/json decodes JSON numbers into float64; a hex string would not
+	// satisfy this assertion.
+	ms, ok := params[1].(float64)
+	if !ok {
+		t.Fatalf("params[1] = %#v (%T), want a JSON number of milliseconds", params[1], params[1])
+	}
+	if ms != 5000 {
+		t.Errorf("timeout = %v ms, want 5000", ms)
+	}
+}
+
+func TestSendRawTransactionSyncBorPreconfirmationReceipt(t *testing.T) {
+	// Bor's preconfirmation receipt: no block hash, plus an explicit marker.
+	tx := testTx(t)
+	receipt := map[string]any{
+		"transactionHash": tx.Hash().Hex(),
+		"status":          "0x1",
+		"gasUsed":         "0x5208",
+		"blockNumber":     "0x2a",
+		"blockHash":       nil,
+		"preconfirmation": true,
+	}
+	rpc := &syncRPC{result: receipt}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := tracker.speculative.Load(); got != 1 {
+		t.Errorf("speculative count = %d, want 1", got)
+	}
+	if got := tracker.canonical.Load(); got != 0 {
+		t.Errorf("canonical count = %d, want 0", got)
+	}
+}
+
+func TestSendRawTransactionSyncMarkerBeatsBlockFields(t *testing.T) {
+	// A node that fills in block fields but says preconfirmation=false is
+	// canonical; the marker is authoritative when present.
+	tx := testTx(t)
+	receipt := canonicalReceipt(tx.Hash())
+	receipt["preconfirmation"] = false
+	rpc := &syncRPC{result: receipt}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := tracker.canonical.Load(); got != 1 {
+		t.Errorf("canonical count = %d, want 1", got)
+	}
+}
+
+func TestSendRawTransactionSyncBorErrorCodes(t *testing.T) {
+	// Bor implements only code 4 from EIP-7966; anything it refuses to accept
+	// fails in SubmitTransaction and returns bor's own codes.
+	tests := []struct {
+		name    string
+		code    int
+		counter func(*SyncTracker) uint64
+	}{
+		{"nonce too high is a gap", SyncErrBorNonceTooHigh, func(t *SyncTracker) uint64 { return t.nonceGaps.Load() }},
+		{"nonce too low is a rejection", SyncErrBorNonceTooLow, func(t *SyncTracker) uint64 { return t.rejected.Load() }},
+		{"intrinsic gas", SyncErrBorIntrinsicGas, func(t *SyncTracker) uint64 { return t.rejected.Load() }},
+		{"insufficient funds", SyncErrBorInsufficientFunds, func(t *SyncTracker) uint64 { return t.rejected.Load() }},
+		{"client limit", SyncErrBorClientLimit, func(t *SyncTracker) uint64 { return t.rejected.Load() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := testTx(t)
+			rpc := &syncRPC{errCode: tt.code, errMsg: tt.name}
+
+			tracker, err := send(t, rpc, &config.Config{}, tx)
+			if err == nil {
+				t.Fatal("expected the rpc error to be returned")
+			}
+			if got := tt.counter(tracker); got != 1 {
+				t.Errorf("counter = %d, want 1", got)
+			}
+			if got := tracker.otherErrs.Load(); got != 0 {
+				t.Errorf("other error count = %d, want 0 (should be classified)", got)
+			}
+		})
+	}
+}
+
+func TestSendRawTransactionSyncCanonicalReceipt(t *testing.T) {
+	tx := testTx(t)
+	rpc := &syncRPC{result: canonicalReceipt(tx.Hash())}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	results := tracker.Results()
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	r := results[0]
+	if r.Speculative {
+		t.Error("receipt with a block should not be classified speculative")
+	}
+	if r.BlockNumber != 42 {
+		t.Errorf("block number = %d, want 42", r.BlockNumber)
+	}
+	if r.GasUsed != 21000 {
+		t.Errorf("gas used = %d, want 21000", r.GasUsed)
+	}
+	if r.Status != types.ReceiptStatusSuccessful {
+		t.Errorf("status = %d, want 1", r.Status)
+	}
+	if got := tracker.canonical.Load(); got != 1 {
+		t.Errorf("canonical count = %d, want 1", got)
+	}
+	if got := tracker.speculative.Load(); got != 0 {
+		t.Errorf("speculative count = %d, want 0", got)
+	}
+}
+
+func TestSendRawTransactionSyncSpeculativeReceipt(t *testing.T) {
+	tx := testTx(t)
+	rpc := &syncRPC{result: speculativeReceipt(tx.Hash())}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	results := tracker.Results()
+	if len(results) != 1 || !results[0].Speculative {
+		t.Fatalf("results = %+v, want one speculative receipt", results)
+	}
+	if got := tracker.speculative.Load(); got != 1 {
+		t.Errorf("speculative count = %d, want 1", got)
+	}
+	if got := tracker.receipts.Load(); got != 1 {
+		t.Errorf("receipt count = %d, want 1", got)
+	}
+}
+
+func TestSendRawTransactionSyncErrorCodes(t *testing.T) {
+	tests := []struct {
+		name    string
+		code    int
+		data    any
+		counter func(*SyncTracker) uint64
+	}{
+		{"timeout", SyncErrTimeout, "0xabc", func(t *SyncTracker) uint64 { return t.timeouts.Load() }},
+		{"queued", SyncErrQueued, "0xabc", func(t *SyncTracker) uint64 { return t.queued.Load() }},
+		{"nonce gap", SyncErrNonceGap, "0x8", func(t *SyncTracker) uint64 { return t.nonceGaps.Load() }},
+		{"unspecified code", -32000, nil, func(t *SyncTracker) uint64 { return t.otherErrs.Load() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := testTx(t)
+			rpc := &syncRPC{errCode: tt.code, errMsg: tt.name, errData: tt.data}
+
+			tracker, err := send(t, rpc, &config.Config{}, tx)
+			if err == nil {
+				t.Fatal("expected the rpc error to be returned")
+			}
+			if code, ok := SyncErrorCode(err); !ok || code != tt.code {
+				t.Errorf("error code = %d (present %v), want %d", code, ok, tt.code)
+			}
+			if got := tt.counter(tracker); got != 1 {
+				t.Errorf("counter = %d, want 1", got)
+			}
+			if got := tracker.receipts.Load(); got != 0 {
+				t.Errorf("receipt count = %d, want 0 on error", got)
+			}
+			results := tracker.Results()
+			if len(results) != 1 || results[0].ErrorCode != tt.code {
+				t.Errorf("results = %+v, want one entry with code %d", results, tt.code)
+			}
+		})
+	}
+}
+
+func TestSendRawTransactionSyncEmptyReceipt(t *testing.T) {
+	// A node that answers with a null result and no error leaves us nothing to
+	// record; it must not count as a receipt.
+	tx := testTx(t)
+	rpc := &syncRPC{result: nil}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := tracker.receipts.Load(); got != 0 {
+		t.Errorf("receipt count = %d, want 0", got)
+	}
+	if got := tracker.otherErrs.Load(); got != 1 {
+		t.Errorf("other error count = %d, want 1", got)
+	}
+}
+
+func TestSendRawTransactionSyncRevertedReceipt(t *testing.T) {
+	tx := testTx(t)
+	receipt := canonicalReceipt(tx.Hash())
+	receipt["status"] = "0x0"
+	rpc := &syncRPC{result: receipt}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := tracker.reverted.Load(); got != 1 {
+		t.Errorf("reverted count = %d, want 1", got)
+	}
+}
+
+func TestSendRawTransactionSyncReceiptWithoutStatus(t *testing.T) {
+	tx := testTx(t)
+	receipt := canonicalReceipt(tx.Hash())
+	delete(receipt, "status")
+	rpc := &syncRPC{result: receipt}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := tracker.noStatus.Load(); got != 1 {
+		t.Errorf("no-status count = %d, want 1", got)
+	}
+	if got := tracker.reverted.Load(); got != 0 {
+		t.Errorf("reverted count = %d, want 0 (absent status is not a revert)", got)
+	}
+}
+
+func TestSyncReceiptClassification(t *testing.T) {
+	zero := common.Hash{}
+	block := common.HexToHash("0xbeef")
+	num := (*hexutil.Big)(big.NewInt(9))
+	yes, no := true, false
+	zeroNum := (*hexutil.Big)(big.NewInt(0))
+
+	tests := []struct {
+		name            string
+		receipt         *SyncReceipt
+		wantSpeculative bool
+	}{
+		{"nil receipt", nil, false},
+		{"no block fields", &SyncReceipt{}, true},
+		{"zero block number", &SyncReceipt{BlockNumber: zeroNum, BlockHash: &block}, true},
+		{"zero block hash", &SyncReceipt{BlockNumber: num, BlockHash: &zero}, true},
+		{"nil block hash", &SyncReceipt{BlockNumber: num}, true},
+		{"full block fields", &SyncReceipt{BlockNumber: num, BlockHash: &block}, false},
+		{"marker true beats block fields", &SyncReceipt{BlockNumber: num, BlockHash: &block, Preconfirmation: &yes}, true},
+		{"marker false beats absent block", &SyncReceipt{Preconfirmation: &no}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.receipt.Speculative(); got != tt.wantSpeculative {
+				t.Errorf("Speculative() = %v, want %v", got, tt.wantSpeculative)
+			}
+		})
+	}
+}
+
+func TestSyncTrackerNilIsSafe(t *testing.T) {
+	var tracker *SyncTracker
+	tracker.Record(common.Hash{}, &SyncReceipt{}, time.Second, nil)
+	tracker.Stats()
+	if got := tracker.Results(); got != nil {
+		t.Errorf("Results() = %v, want nil", got)
+	}
+}
+
+func TestSyncTrackerConcurrentRecord(t *testing.T) {
+	tracker := NewSyncTracker()
+	const goroutines = 32
+	const each = 20
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := range each {
+				hash := common.BigToHash(big.NewInt(int64(i*each + j)))
+				if j%2 == 0 {
+					tracker.Record(hash, &SyncReceipt{}, time.Millisecond, nil)
+				} else {
+					tracker.Record(hash, nil, time.Millisecond, fmt.Errorf("boom"))
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if got := tracker.submitted.Load(); got != goroutines*each {
+		t.Errorf("submitted = %d, want %d", got, goroutines*each)
+	}
+	if got := len(tracker.Results()); got != goroutines*each {
+		t.Errorf("results = %d, want %d", got, goroutines*each)
+	}
+	tracker.Stats()
+}

--- a/loadtest/mode/synctx_test.go
+++ b/loadtest/mode/synctx_test.go
@@ -636,3 +636,25 @@ func TestSendRawTransactionSyncNoReceiptLogBelowTrace(t *testing.T) {
 		t.Errorf("receipt logged below trace level: %s", out)
 	}
 }
+
+func TestLogReceiptTraceCustomMessages(t *testing.T) {
+	// The runner's --wait-for-receipt path reuses this helper with its own
+	// messages; make sure they carry through on both outcomes.
+	buf := captureTraceLogs(t, zerolog.TraceLevel)
+
+	hash := common.HexToHash("0xf00d")
+	raw := json.RawMessage(`{"transactionHash":"0xf00d","status":"0x1"}`)
+	LogReceiptTrace(hash, raw, 42*time.Millisecond, nil, "Transaction receipt", "Receipt wait failed")
+	LogReceiptTrace(hash, nil, 42*time.Millisecond, fmt.Errorf("boom"), "Transaction receipt", "Receipt wait failed")
+
+	out := buf.String()
+	if !strings.Contains(out, "Transaction receipt") {
+		t.Errorf("success message missing: %s", out)
+	}
+	if !strings.Contains(out, `"status":"0x1"`) {
+		t.Errorf("raw receipt missing: %s", out)
+	}
+	if !strings.Contains(out, "Receipt wait failed") || !strings.Contains(out, "boom") {
+		t.Errorf("failure message missing: %s", out)
+	}
+}

--- a/loadtest/mode/synctx_test.go
+++ b/loadtest/mode/synctx_test.go
@@ -1,11 +1,13 @@
 package mode
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,6 +17,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/0xPolygon/polygon-cli/loadtest/config"
 )
@@ -533,5 +537,102 @@ func TestSyncTrackerCanonicalReceiptWithoutBlockNumber(t *testing.T) {
 	}
 	if results[0].BlockNumber != 0 {
 		t.Errorf("block number = %d, want 0", results[0].BlockNumber)
+	}
+}
+
+// captureTraceLogs redirects the global logger into a buffer at the given
+// level and restores it when the test finishes.
+func captureTraceLogs(t *testing.T, level zerolog.Level) *bytes.Buffer {
+	t.Helper()
+	origLogger := log.Logger
+	origLevel := zerolog.GlobalLevel()
+	t.Cleanup(func() {
+		log.Logger = origLogger
+		zerolog.SetGlobalLevel(origLevel)
+	})
+
+	var buf bytes.Buffer
+	log.Logger = zerolog.New(&buf)
+	zerolog.SetGlobalLevel(level)
+	return &buf
+}
+
+func TestSendRawTransactionSyncMalformedReceipt(t *testing.T) {
+	// A result that is valid JSON but not a receipt must surface as an error,
+	// not as a receipt or a silent nil.
+	tx := testTx(t)
+	rpc := &syncRPC{result: map[string]any{"status": []string{"0x1"}}}
+
+	tracker, err := send(t, rpc, &config.Config{}, tx)
+	if err == nil || !strings.Contains(err.Error(), "failed to decode sync receipt") {
+		t.Fatalf("err = %v, want a decode error", err)
+	}
+	if got := tracker.receipts.Load(); got != 0 {
+		t.Errorf("receipt count = %d, want 0", got)
+	}
+	if got := tracker.otherErrs.Load(); got != 1 {
+		t.Errorf("other error count = %d, want 1", got)
+	}
+}
+
+func TestSendRawTransactionSyncTraceLogsRawReceipt(t *testing.T) {
+	buf := captureTraceLogs(t, zerolog.TraceLevel)
+
+	tx := testTx(t)
+	receipt := canonicalReceipt(tx.Hash())
+	// A field SyncReceipt does not model proves the receipt is logged verbatim.
+	receipt["effectiveGasPrice"] = "0x77359400"
+	rpc := &syncRPC{result: receipt}
+
+	if _, err := send(t, rpc, &config.Config{}, tx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Sync transaction receipt") {
+		t.Fatalf("expected a trace receipt log, got: %s", out)
+	}
+	if !strings.Contains(out, `"effectiveGasPrice":"0x77359400"`) {
+		t.Errorf("raw receipt not logged verbatim: %s", out)
+	}
+	if !strings.Contains(out, tx.Hash().Hex()) {
+		t.Errorf("tx hash missing from receipt log: %s", out)
+	}
+}
+
+func TestSendRawTransactionSyncTraceLogsErrors(t *testing.T) {
+	buf := captureTraceLogs(t, zerolog.TraceLevel)
+
+	tx := testTx(t)
+	rpc := &syncRPC{errCode: SyncErrTimeout, errMsg: "receipt wait timed out", errData: "0xabc"}
+
+	if _, err := send(t, rpc, &config.Config{}, tx); err == nil {
+		t.Fatal("expected the rpc error to be returned")
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Sync transaction submission failed") {
+		t.Fatalf("expected a trace error log, got: %s", out)
+	}
+	if !strings.Contains(out, `"errorCode":4`) {
+		t.Errorf("error code missing from log: %s", out)
+	}
+	if !strings.Contains(out, `"errorData":"0xabc"`) {
+		t.Errorf("error data missing from log: %s", out)
+	}
+}
+
+func TestSendRawTransactionSyncNoReceiptLogBelowTrace(t *testing.T) {
+	buf := captureTraceLogs(t, zerolog.InfoLevel)
+
+	tx := testTx(t)
+	rpc := &syncRPC{result: canonicalReceipt(tx.Hash())}
+
+	if _, err := send(t, rpc, &config.Config{}, tx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out := buf.String(); strings.Contains(out, "Sync transaction receipt") {
+		t.Errorf("receipt logged below trace level: %s", out)
 	}
 }

--- a/loadtest/mode/synctx_test.go
+++ b/loadtest/mode/synctx_test.go
@@ -516,3 +516,22 @@ func TestSyncTrackerConcurrentRecord(t *testing.T) {
 	}
 	tracker.Stats()
 }
+
+func TestSyncTrackerCanonicalReceiptWithoutBlockNumber(t *testing.T) {
+	// preconfirmation=false is authoritative, so this receipt is canonical even
+	// though it carries no block fields to read a block number from.
+	no := false
+	tracker := NewSyncTracker()
+	tracker.Record(common.Hash{}, &SyncReceipt{Preconfirmation: &no}, time.Millisecond, nil)
+
+	if got := tracker.canonical.Load(); got != 1 {
+		t.Errorf("canonical count = %d, want 1", got)
+	}
+	results := tracker.Results()
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].BlockNumber != 0 {
+		t.Errorf("block number = %d, want 0", results[0].BlockNumber)
+	}
+}

--- a/loadtest/mode/util.go
+++ b/loadtest/mode/util.go
@@ -135,3 +135,19 @@ func SendRawTransactionPrivate(ctx context.Context, rpcClient *ethrpc.Client, tx
 	var txHash common.Hash
 	return rpcClient.CallContext(ctx, &txHash, "eth_sendRawTransactionPrivate", hexutil.Encode(rawTx))
 }
+
+// SendSignedTransaction broadcasts a signed transaction using whichever send
+// path the configuration selects. Modes that build and sign their own
+// transactions share this so a new send method only has to be wired in once.
+func SendSignedTransaction(ctx context.Context, deps *Dependencies, cfg *config.Config, tx *types.Transaction) error {
+	switch {
+	case cfg.OutputRawTxOnly:
+		return OutputRawTransaction(tx)
+	case cfg.SyncTxs:
+		return SendRawTransactionSync(ctx, deps, cfg, tx)
+	case cfg.PrivateTxs:
+		return SendRawTransactionPrivate(ctx, deps.SendRPCClient, tx)
+	default:
+		return deps.SendClient.SendTransaction(ctx, tx)
+	}
+}

--- a/loadtest/modes/blob.go
+++ b/loadtest/modes/blob.go
@@ -113,6 +113,8 @@ func (m *BlobMode) Execute(ctx context.Context, cfg *config.Config, deps *mode.D
 		return
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
+	} else if cfg.SyncTxs {
+		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
 	} else if cfg.PrivateTxs {
 		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {

--- a/loadtest/modes/blob.go
+++ b/loadtest/modes/blob.go
@@ -111,15 +111,9 @@ func (m *BlobMode) Execute(ctx context.Context, cfg *config.Config, deps *mode.D
 		err = fmt.Errorf("CallOnly not supported for blob transactions")
 		log.Error().Err(err).Msg("Cannot use call-only mode with blob transactions")
 		return
-	} else if cfg.OutputRawTxOnly {
-		err = mode.OutputRawTransaction(stx)
-	} else if cfg.SyncTxs {
-		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
-	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
-	} else {
-		err = deps.SendClient.SendTransaction(ctx, stx)
 	}
+
+	err = mode.SendSignedTransaction(ctx, deps, cfg, stx)
 	return
 }
 

--- a/loadtest/modes/contractcall.go
+++ b/loadtest/modes/contractcall.go
@@ -124,6 +124,8 @@ func (m *ContractCallMode) Execute(ctx context.Context, cfg *config.Config, deps
 		_, err = deps.Client.CallContract(ctx, mode.TxToCallMsg(cfg, stx), nil)
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
+	} else if cfg.SyncTxs {
+		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
 	} else if cfg.PrivateTxs {
 		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {

--- a/loadtest/modes/contractcall.go
+++ b/loadtest/modes/contractcall.go
@@ -122,14 +122,8 @@ func (m *ContractCallMode) Execute(ctx context.Context, cfg *config.Config, deps
 
 	if cfg.EthCallOnly {
 		_, err = deps.Client.CallContract(ctx, mode.TxToCallMsg(cfg, stx), nil)
-	} else if cfg.OutputRawTxOnly {
-		err = mode.OutputRawTransaction(stx)
-	} else if cfg.SyncTxs {
-		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
-	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.SendClient.SendTransaction(ctx, stx)
+		err = mode.SendSignedTransaction(ctx, deps, cfg, stx)
 	}
 	return
 }

--- a/loadtest/modes/recall.go
+++ b/loadtest/modes/recall.go
@@ -104,6 +104,8 @@ func (m *RecallMode) Execute(ctx context.Context, cfg *config.Config, deps *mode
 		err = nil
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
+	} else if cfg.SyncTxs {
+		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
 	} else if cfg.PrivateTxs {
 		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {

--- a/loadtest/modes/recall.go
+++ b/loadtest/modes/recall.go
@@ -102,14 +102,8 @@ func (m *RecallMode) Execute(ctx context.Context, cfg *config.Config, deps *mode
 		}
 		// we're not going to return the error in the case because there is no point retrying
 		err = nil
-	} else if cfg.OutputRawTxOnly {
-		err = mode.OutputRawTransaction(stx)
-	} else if cfg.SyncTxs {
-		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
-	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.SendClient.SendTransaction(ctx, stx)
+		err = mode.SendSignedTransaction(ctx, deps, cfg, stx)
 	}
 	return
 }

--- a/loadtest/modes/transaction.go
+++ b/loadtest/modes/transaction.go
@@ -91,14 +91,8 @@ func (m *TransactionMode) Execute(ctx context.Context, cfg *config.Config, deps 
 	defer func() { end = time.Now() }()
 	if cfg.EthCallOnly {
 		_, err = deps.Client.CallContract(ctx, mode.TxToCallMsg(cfg, stx), nil)
-	} else if cfg.OutputRawTxOnly {
-		err = mode.OutputRawTransaction(stx)
-	} else if cfg.SyncTxs {
-		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
-	} else if cfg.PrivateTxs {
-		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {
-		err = deps.SendClient.SendTransaction(ctx, stx)
+		err = mode.SendSignedTransaction(ctx, deps, cfg, stx)
 	}
 
 	return

--- a/loadtest/modes/transaction.go
+++ b/loadtest/modes/transaction.go
@@ -93,6 +93,8 @@ func (m *TransactionMode) Execute(ctx context.Context, cfg *config.Config, deps 
 		_, err = deps.Client.CallContract(ctx, mode.TxToCallMsg(cfg, stx), nil)
 	} else if cfg.OutputRawTxOnly {
 		err = mode.OutputRawTransaction(stx)
+	} else if cfg.SyncTxs {
+		err = mode.SendRawTransactionSync(ctx, deps, cfg, stx)
 	} else if cfg.PrivateTxs {
 		err = mode.SendRawTransactionPrivate(ctx, deps.SendRPCClient, stx)
 	} else {

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -3,6 +3,7 @@ package loadtest
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -758,9 +759,19 @@ func (r *Runner) mainLoop(ctx context.Context) error {
 					go r.preconfTracker.Track(ltTxHash)
 				}
 
-				// Wait for receipt if configured
+				// Wait for receipt if configured. This blocks the sending
+				// goroutine; the raw receipt is trace-logged so it can be
+				// audited later.
 				if tErr == nil && cfg.WaitForReceipt {
-					_, tErr = util.WaitReceiptWithRetries(ctx, r.client, ltTxHash, cfg.ReceiptRetryMax, cfg.ReceiptRetryDelay)
+					waitStart := time.Now()
+					var rawReceipt json.RawMessage
+					rawReceipt, tErr = util.WaitReceiptRaw(ctx, r.rpcClient, ltTxHash, util.ReceiptWaitOpts{
+						MaxAttempts:  cfg.ReceiptRetryMax,
+						InitialDelay: time.Duration(cfg.ReceiptRetryDelay) * time.Millisecond,
+						Interval:     cfg.ReceiptPollInterval,
+					})
+					mode.LogReceiptTrace(ltTxHash, rawReceipt, time.Since(waitStart), tErr,
+						"Transaction receipt", "Receipt wait failed")
 				}
 
 				// Handle errors

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -560,11 +560,10 @@ func (r *Runner) postLoadTest(ctx context.Context) {
 	cfg := r.cfg
 	results := r.GetResults()
 
-	// Output preconf stats if tracker was used
-	if r.deps != nil && r.deps.SyncTracker != nil {
+	// Output tracker stats. SyncTracker.Stats is a no-op on a nil tracker.
+	if r.deps != nil {
 		r.deps.SyncTracker.Stats()
 	}
-
 	if r.preconfTracker != nil {
 		r.preconfTracker.Stats()
 	}
@@ -1727,7 +1726,6 @@ func (r *Runner) waitForFinalBlock(ctx context.Context) (uint64, error) {
 			timer.Stop()
 			return lastBlockNumber, ctx.Err()
 		}
-		timer.Stop()
 	}
 
 	log.Error().Msg("Max retries reached waiting for transactions to be mined")

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -1388,6 +1388,33 @@ func (r *Runner) biasGasPrice(price *big.Int) *big.Int {
 	return result
 }
 
+// cachedPrices returns the cached gas price and tip cap, substituting zero for
+// either one that has not been populated yet. Every fallback path in
+// getSuggestedGasPrices can be reached before the cache is first written -- an
+// RPC error on the very first call does exactly that -- and callers dereference
+// the result without checking, so returning nil from there panics the run.
+//
+// Zero-priced transactions are rejected by the node and surface as recorded
+// send errors, which is the same outcome the account pool settles for and a far
+// better one than a stack trace. The RPC error itself is already logged at each
+// fallback site.
+//
+// The values are copies: they outlive the lock, every sending goroutine holds
+// one at once, and handing out the cached pointers would make any in-place
+// arithmetic by a caller a silent data race on shared state.
+//
+// The caller must hold cachedGasPriceLock.
+func (r *Runner) cachedPrices() (*big.Int, *big.Int) {
+	gasPrice, gasTipCap := new(big.Int), new(big.Int)
+	if r.cachedGasPrice != nil {
+		gasPrice.Set(r.cachedGasPrice)
+	}
+	if r.cachedGasTipCap != nil {
+		gasTipCap.Set(r.cachedGasTipCap)
+	}
+	return gasPrice, gasTipCap
+}
+
 func (r *Runner) getSuggestedGasPrices(ctx context.Context) (*big.Int, *big.Int) {
 	r.cachedGasPriceLock.Lock()
 	defer r.cachedGasPriceLock.Unlock()
@@ -1397,7 +1424,7 @@ func (r *Runner) getSuggestedGasPrices(ctx context.Context) (*big.Int, *big.Int)
 	// Cache is used only when gas pricer is not used
 	if r.gasPricer == nil {
 		if r.cachedBlockNumber != nil && bn <= *r.cachedBlockNumber {
-			return r.cachedGasPrice, r.cachedGasTipCap
+			return r.cachedPrices()
 		}
 	}
 
@@ -1417,14 +1444,14 @@ func (r *Runner) getSuggestedGasPrices(ctx context.Context) (*big.Int, *big.Int)
 				gasPrice = big.NewInt(0).SetUint64(*gp)
 			} else {
 				if r.cachedBlockNumber != nil && bn <= *r.cachedBlockNumber {
-					return r.cachedGasPrice, r.cachedGasTipCap
+					return r.cachedPrices()
 				}
 				gasPrice, pErr = r.client.SuggestGasPrice(ctx)
 				if pErr == nil {
 					gasPrice = r.biasGasPrice(gasPrice)
 				} else {
 					log.Error().Err(pErr).Msg("Unable to suggest gas price")
-					return r.cachedGasPrice, r.cachedGasTipCap
+					return r.cachedPrices()
 				}
 			}
 		}
@@ -1435,14 +1462,14 @@ func (r *Runner) getSuggestedGasPrices(ctx context.Context) (*big.Int, *big.Int)
 			forcePriorityGasPrice = gasTipCap
 		} else if cfg.ChainSupportBaseFee {
 			if r.cachedBlockNumber != nil && bn <= *r.cachedBlockNumber {
-				gasTipCap = r.cachedGasTipCap
+				_, gasTipCap = r.cachedPrices()
 			} else {
 				gasTipCap, tErr = r.client.SuggestGasTipCap(ctx)
 				if tErr == nil {
 					gasTipCap = r.biasGasPrice(gasTipCap)
 				} else {
 					log.Error().Err(tErr).Msg("Unable to suggest gas tip cap")
-					return r.cachedGasPrice, r.cachedGasTipCap
+					return r.cachedPrices()
 				}
 			}
 		} else {
@@ -1460,9 +1487,14 @@ func (r *Runner) getSuggestedGasPrices(ctx context.Context) (*big.Int, *big.Int)
 				gasPrice = big.NewInt(0).SetUint64(*gp)
 			} else {
 				if r.cachedBlockNumber != nil && bn <= *r.cachedBlockNumber {
-					return r.cachedGasPrice, r.cachedGasTipCap
+					return r.cachedPrices()
 				}
 				gasPrice = r.suggestMaxFeePerGas(ctx, bn, forcePriorityGasPrice)
+				if gasPrice == nil {
+					// suggestMaxFeePerGas already logged why. Keep the last
+					// known price rather than caching a nil one.
+					return r.cachedPrices()
+				}
 			}
 		} else {
 			log.Fatal().Msg("Chain does not support base fee. Please set gas-price flag with a value to use for max fee per gas")
@@ -1482,7 +1514,7 @@ func (r *Runner) getSuggestedGasPrices(ctx context.Context) (*big.Int, *big.Int)
 			Msg("Updating gas prices")
 	}
 
-	return r.cachedGasPrice, r.cachedGasTipCap
+	return r.cachedPrices()
 }
 
 func (r *Runner) suggestMaxFeePerGas(ctx context.Context, blockNumber uint64, forcePriorityFee *big.Int) *big.Int {
@@ -1607,10 +1639,22 @@ func (r *Runner) waitForFinalBlock(ctx context.Context) (uint64, error) {
 	const checkInterval = 5 * time.Second
 	const maxRetries = 30
 
-	rateLimiter := rate.NewLimiter(rate.Limit(cfg.RateLimit), 1)
+	// A non-positive --rate-limit means no limit, the same reading the main loop
+	// applies. Constructing a limiter from it instead produced a negative
+	// rate.Limit, whose tokens never replenish: the first nonce check took the
+	// initial token and every later one blocked on Wait forever, so wg.Wait
+	// below never returned and the run hung after sending.
+	var rateLimiter *rate.Limiter
+	if cfg.RateLimit > 0 {
+		rateLimiter = rate.NewLimiter(rate.Limit(cfg.RateLimit), 1)
+	}
 	noncesToCheck := r.accountPool.Nonces(ctx, true)
 
 	for retry := 1; retry <= maxRetries; retry++ {
+		if err = ctx.Err(); err != nil {
+			return lastBlockNumber, err
+		}
+
 		lastBlockNumber, err = r.client.BlockNumber(ctx)
 		if err != nil {
 			return 0, err
@@ -1628,9 +1672,11 @@ func (r *Runner) waitForFinalBlock(ctx context.Context) (uint64, error) {
 			expectedNonce := value.(uint64)
 			go func(ctx context.Context, rl *rate.Limiter) {
 				defer wg.Done()
-				if waitErr := rl.Wait(ctx); waitErr != nil {
-					log.Error().Err(waitErr).Msg("Rate limiter wait error")
-					return
+				if rl != nil {
+					if waitErr := rl.Wait(ctx); waitErr != nil {
+						log.Error().Err(waitErr).Msg("Rate limiter wait error")
+						return
+					}
 				}
 				nonce, nonceErr := r.client.NonceAt(ctx, address, new(big.Int).SetUint64(lastBlockNumber))
 				if nonceErr != nil {
@@ -1663,7 +1709,15 @@ func (r *Runner) waitForFinalBlock(ctx context.Context) (uint64, error) {
 			Int("retry", retry).
 			Int("maxRetries", maxRetries).
 			Msg("Waiting for transactions to be mined...")
-		time.Sleep(checkInterval)
+
+		timer := time.NewTimer(checkInterval)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return lastBlockNumber, ctx.Err()
+		}
+		timer.Stop()
 	}
 
 	log.Error().Msg("Max retries reached waiting for transactions to be mined")

--- a/loadtest/runner.go
+++ b/loadtest/runner.go
@@ -166,6 +166,12 @@ func (r *Runner) Init(ctx context.Context) error {
 		return err
 	}
 
+	// Initialize the synchronous submission tracker if configured. It lives on
+	// deps because the send helper records into it from inside each mode.
+	if r.cfg.SyncTxs {
+		r.deps.SyncTracker = mode.NewSyncTracker()
+	}
+
 	// Initialize preconf tracker if configured
 	if r.cfg.CheckForPreconf {
 		r.preconfTracker = NewPreconfTracker(r.client, r.cfg.PreconfStatsFile)
@@ -555,6 +561,10 @@ func (r *Runner) postLoadTest(ctx context.Context) {
 	results := r.GetResults()
 
 	// Output preconf stats if tracker was used
+	if r.deps != nil && r.deps.SyncTracker != nil {
+		r.deps.SyncTracker.Stats()
+	}
+
 	if r.preconfTracker != nil {
 		r.preconfTracker.Stats()
 	}

--- a/loadtest/runner_test.go
+++ b/loadtest/runner_test.go
@@ -1,11 +1,19 @@
 package loadtest
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/0xPolygon/polygon-cli/loadtest/config"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 func TestComputeReverseTxsPerAccount(t *testing.T) {
@@ -129,5 +137,187 @@ func TestNonceTooLowRegexp(t *testing.T) {
 				t.Errorf("nextNonce = %d, want %d", nextNonce, tt.wantNextNonce)
 			}
 		})
+	}
+}
+
+func TestCachedPricesNeverReturnsNil(t *testing.T) {
+	// Every fallback in getSuggestedGasPrices can be reached before the cache
+	// is written, and configureTransactOpts dereferences what it gets, so a nil
+	// here used to panic the whole run.
+	tests := []struct {
+		name       string
+		gasPrice   *big.Int
+		gasTipCap  *big.Int
+		wantPrice  int64
+		wantTipCap int64
+	}{
+		{"empty cache", nil, nil, 0, 0},
+		{"price only", big.NewInt(7), nil, 7, 0},
+		{"tip cap only", nil, big.NewInt(3), 0, 3},
+		{"both cached", big.NewInt(7), big.NewInt(3), 7, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Runner{cachedGasPrice: tt.gasPrice, cachedGasTipCap: tt.gasTipCap}
+
+			gasPrice, gasTipCap := r.cachedPrices()
+			if gasPrice == nil || gasTipCap == nil {
+				t.Fatalf("cachedPrices() = (%v, %v), want non-nil values", gasPrice, gasTipCap)
+			}
+			if gasPrice.Int64() != tt.wantPrice {
+				t.Errorf("gas price = %s, want %d", gasPrice, tt.wantPrice)
+			}
+			if gasTipCap.Int64() != tt.wantTipCap {
+				t.Errorf("gas tip cap = %s, want %d", gasTipCap, tt.wantTipCap)
+			}
+
+			// The values must be usable the way the caller uses them.
+			if gasTipCap.Cmp(gasPrice) > 0 {
+				gasTipCap = new(big.Int).Set(gasPrice)
+			}
+			_ = gasTipCap
+		})
+	}
+}
+
+func TestCachedPricesDoesNotAliasTheCache(t *testing.T) {
+	// A caller that clamps the tip cap must not mutate the cached value.
+	r := &Runner{cachedGasPrice: big.NewInt(10), cachedGasTipCap: big.NewInt(4)}
+
+	_, gasTipCap := r.cachedPrices()
+	gasTipCap.SetInt64(99)
+
+	if got := r.cachedGasTipCap.Int64(); got != 4 {
+		t.Errorf("cached tip cap = %d, want 4 (unchanged)", got)
+	}
+}
+
+func TestWaitForFinalBlockRespectsCancellation(t *testing.T) {
+	// The retry loop used a bare time.Sleep, so 30 retries held the process for
+	// 150s past a Ctrl+C. It must return as soon as the context is done.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var body struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// A node whose nonce never advances: the wait can never succeed.
+		result := "0x1"
+		if body.Method == "eth_getTransactionCount" {
+			result = "0x0"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%q}`, body.ID, result); err != nil {
+			t.Errorf("failed to write rpc response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := ethclient.DialContext(t.Context(), server.URL)
+	if err != nil {
+		t.Fatalf("failed to dial fake rpc: %v", err)
+	}
+	defer client.Close()
+
+	pool := newTestAccountPool(&Account{
+		address:    common.BytesToAddress([]byte{1}),
+		ready:      true,
+		startNonce: 0,
+		nonce:      5, // outstanding transactions that will never be mined
+	})
+
+	// Negative rate limit means "no limit"; building a limiter from it used to
+	// block every nonce check after the first forever.
+	r := &Runner{
+		cfg:         &config.Config{RateLimit: -1},
+		client:      client,
+		accountPool: pool,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, waitErr := r.waitForFinalBlock(ctx)
+		done <- waitErr
+	}()
+
+	// Give it long enough to enter the retry sleep, then cancel.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	select {
+	case waitErr := <-done:
+		if waitErr == nil {
+			t.Error("expected an error after cancellation")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("waitForFinalBlock did not return after context cancellation")
+	}
+}
+
+func TestWaitForFinalBlockCompletesWithoutRateLimit(t *testing.T) {
+	// With --rate-limit -1 and all nonces mined, the wait must finish promptly
+	// rather than blocking on a limiter whose tokens never come back.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var body struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+		}
+		if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		result := "0x63" // block number, and a nonce well past what we expect
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprintf(w, `{"jsonrpc":"2.0","id":%s,"result":%q}`, body.ID, result); err != nil {
+			t.Errorf("failed to write rpc response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := ethclient.DialContext(t.Context(), server.URL)
+	if err != nil {
+		t.Fatalf("failed to dial fake rpc: %v", err)
+	}
+	defer client.Close()
+
+	// Several accounts: with a negative-rate limiter, the first would pass and
+	// the rest would hang.
+	accounts := make([]*Account, 5)
+	for i := range accounts {
+		accounts[i] = &Account{
+			address:    common.BytesToAddress([]byte{byte(i + 1)}),
+			ready:      true,
+			startNonce: 0,
+			nonce:      3,
+		}
+	}
+
+	r := &Runner{
+		cfg:         &config.Config{RateLimit: -1},
+		client:      client,
+		accountPool: newTestAccountPool(accounts...),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		blockNumber, waitErr := r.waitForFinalBlock(t.Context())
+		if waitErr != nil {
+			t.Errorf("waitForFinalBlock failed: %v", waitErr)
+		}
+		if blockNumber != 0x63 {
+			t.Errorf("block number = %d, want 99", blockNumber)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("waitForFinalBlock blocked with rate limiting disabled")
 	}
 }

--- a/loadtest/runner_test.go
+++ b/loadtest/runner_test.go
@@ -171,12 +171,6 @@ func TestCachedPricesNeverReturnsNil(t *testing.T) {
 			if gasTipCap.Int64() != tt.wantTipCap {
 				t.Errorf("gas tip cap = %s, want %d", gasTipCap, tt.wantTipCap)
 			}
-
-			// The values must be usable the way the caller uses them.
-			if gasTipCap.Cmp(gasPrice) > 0 {
-				gasTipCap = new(big.Int).Set(gasPrice)
-			}
-			_ = gasTipCap
 		})
 	}
 }

--- a/util/receipt.go
+++ b/util/receipt.go
@@ -1,7 +1,9 @@
 package util
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"time"
@@ -9,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
 // WaitReceipt waits for a transaction receipt with default parameters.
@@ -79,6 +82,87 @@ func internalWaitReceipt(ctx context.Context, client *ethclient.Client, txHash c
 			return nil, timeoutCtx.Err()
 		case <-time.After(totalDelay):
 			// Continue
+		}
+	}
+}
+
+// ReceiptWaitOpts controls how WaitReceiptRaw polls for a receipt.
+type ReceiptWaitOpts struct {
+	// MaxAttempts caps the number of polls in backoff mode (0 means unbounded
+	// within Timeout). Ignored when Interval is set.
+	MaxAttempts uint
+	// InitialDelay is the starting delay for exponential backoff, default
+	// 100ms. Ignored when Interval is set.
+	InitialDelay time.Duration
+	// Interval, when positive, switches to fixed-interval polling bounded only
+	// by Timeout.
+	Interval time.Duration
+	// Timeout bounds the whole wait, default 1 minute.
+	Timeout time.Duration
+}
+
+var jsonNull = []byte("null")
+
+// WaitReceiptRaw polls eth_getTransactionReceipt until the receipt exists and
+// returns it as raw JSON, so callers can log or inspect fields beyond what
+// types.Receipt models. Polling is either exponential backoff with jitter
+// (matching WaitReceiptWithRetries) or a fixed interval, per opts.
+func WaitReceiptRaw(ctx context.Context, rpc *ethrpc.Client, txHash common.Hash, opts ReceiptWaitOpts) (json.RawMessage, error) {
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = 1 * time.Minute
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	initialDelay := opts.InitialDelay
+	if initialDelay == 0 {
+		initialDelay = 100 * time.Millisecond
+	} else if initialDelay < 10*time.Millisecond {
+		initialDelay = 10 * time.Millisecond
+	}
+
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	<-timer.C
+
+	for attempt := uint(0); ; attempt++ {
+		var raw json.RawMessage
+		err := rpc.CallContext(timeoutCtx, &raw, "eth_getTransactionReceipt", txHash)
+		// A pending or unknown transaction is a null result with no error at
+		// the RPC layer, so both outcomes mean "not yet" here.
+		if err == nil && len(raw) > 0 && !bytes.Equal(raw, jsonNull) {
+			return raw, nil
+		}
+
+		var delay time.Duration
+		if opts.Interval > 0 {
+			// Fixed-interval polling is bounded only by the timeout.
+			delay = opts.Interval
+		} else {
+			if opts.MaxAttempts > 0 && attempt >= opts.MaxAttempts-1 {
+				if err == nil {
+					err = fmt.Errorf("transaction %s has no receipt", txHash.Hex())
+				}
+				return nil, fmt.Errorf("failed to get receipt after %d attempts: %w", opts.MaxAttempts, err)
+			}
+			delay = initialDelay * time.Duration(1<<attempt)
+			maxDelay := 30 * time.Second
+			if delay > maxDelay {
+				delay = maxDelay
+			}
+			maxJitter := delay / 2
+			if maxJitter <= 0 {
+				maxJitter = 1 * time.Millisecond
+			}
+			delay += time.Duration(rand.Int63n(int64(maxJitter)))
+		}
+
+		timer.Reset(delay)
+		select {
+		case <-timeoutCtx.Done():
+			return nil, timeoutCtx.Err()
+		case <-timer.C:
 		}
 	}
 }

--- a/util/receipt_test.go
+++ b/util/receipt_test.go
@@ -1,0 +1,205 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethrpc "github.com/ethereum/go-ethereum/rpc"
+)
+
+// receiptRPC is a fake JSON-RPC endpoint for eth_getTransactionReceipt that
+// answers null for the first pendingPolls calls and the canned receipt after.
+type receiptRPC struct {
+	t *testing.T
+
+	pendingPolls int
+	receipt      map[string]any
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *receiptRPC) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *receiptRPC) handle(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Method != "eth_getTransactionReceipt" {
+		http.Error(w, "unexpected method "+req.Method, http.StatusBadRequest)
+		return
+	}
+
+	s.mu.Lock()
+	s.calls++
+	var result any
+	if s.calls > s.pendingPolls {
+		result = s.receipt
+	}
+	s.mu.Unlock()
+
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": json.RawMessage(req.ID), "result": result,
+	})
+	if err != nil {
+		s.t.Errorf("failed to marshal rpc response: %v", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if _, werr := w.Write(payload); werr != nil {
+		s.t.Errorf("failed to write rpc response: %v", werr)
+	}
+}
+
+func newReceiptRPC(t *testing.T, s *receiptRPC) *ethrpc.Client {
+	t.Helper()
+	s.t = t
+	server := httptest.NewServer(http.HandlerFunc(s.handle))
+	t.Cleanup(server.Close)
+
+	client, err := ethrpc.DialContext(t.Context(), server.URL)
+	if err != nil {
+		t.Fatalf("failed to dial fake rpc: %v", err)
+	}
+	t.Cleanup(client.Close)
+	return client
+}
+
+func TestWaitReceiptRawFixedInterval(t *testing.T) {
+	txHash := common.HexToHash("0xf00d")
+	rpc := &receiptRPC{
+		pendingPolls: 3,
+		receipt: map[string]any{
+			"transactionHash": txHash.Hex(),
+			"status":          "0x1",
+			// A field types.Receipt doesn't require, proving raw passthrough.
+			"effectiveGasPrice": "0x77359400",
+		},
+	}
+	client := newReceiptRPC(t, rpc)
+
+	raw, err := WaitReceiptRaw(t.Context(), client, txHash, ReceiptWaitOpts{
+		Interval: 10 * time.Millisecond,
+		// MaxAttempts must be ignored in interval mode: fewer than the polls
+		// needed to see the receipt.
+		MaxAttempts: 2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := rpc.callCount(); got != 4 {
+		t.Errorf("poll count = %d, want 4 (3 pending + 1 found)", got)
+	}
+	if !strings.Contains(string(raw), `"effectiveGasPrice":"0x77359400"`) {
+		t.Errorf("raw receipt not passed through verbatim: %s", raw)
+	}
+}
+
+func TestWaitReceiptRawFixedIntervalTimesOut(t *testing.T) {
+	txHash := common.HexToHash("0xf00d")
+	rpc := &receiptRPC{pendingPolls: 1 << 30} // never found
+	client := newReceiptRPC(t, rpc)
+
+	start := time.Now()
+	_, err := WaitReceiptRaw(t.Context(), client, txHash, ReceiptWaitOpts{
+		Interval: 20 * time.Millisecond,
+		Timeout:  150 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("wait took %s, expected to stop at the ~150ms timeout", elapsed)
+	}
+	if got := rpc.callCount(); got < 3 {
+		t.Errorf("poll count = %d, want steady polling before the timeout", got)
+	}
+}
+
+func TestWaitReceiptRawBackoffExhaustsAttempts(t *testing.T) {
+	txHash := common.HexToHash("0xf00d")
+	rpc := &receiptRPC{pendingPolls: 1 << 30} // never found
+	client := newReceiptRPC(t, rpc)
+
+	_, err := WaitReceiptRaw(t.Context(), client, txHash, ReceiptWaitOpts{
+		MaxAttempts:  3,
+		InitialDelay: 10 * time.Millisecond,
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed to get receipt after 3 attempts") {
+		t.Fatalf("err = %v, want attempts-exhausted error", err)
+	}
+	if got := rpc.callCount(); got != 3 {
+		t.Errorf("poll count = %d, want exactly 3", got)
+	}
+}
+
+func TestWaitReceiptRawBackoffFindsReceipt(t *testing.T) {
+	txHash := common.HexToHash("0xf00d")
+	rpc := &receiptRPC{
+		pendingPolls: 2,
+		receipt:      map[string]any{"transactionHash": txHash.Hex(), "status": "0x1"},
+	}
+	client := newReceiptRPC(t, rpc)
+
+	raw, err := WaitReceiptRaw(t.Context(), client, txHash, ReceiptWaitOpts{
+		MaxAttempts:  10,
+		InitialDelay: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(raw), txHash.Hex()) {
+		t.Errorf("raw receipt missing tx hash: %s", raw)
+	}
+}
+
+func TestWaitReceiptRawContextCancellation(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		opts ReceiptWaitOpts
+	}{
+		{"fixed interval", ReceiptWaitOpts{Interval: 50 * time.Millisecond}},
+		{"backoff", ReceiptWaitOpts{InitialDelay: 50 * time.Millisecond}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			txHash := common.HexToHash("0xf00d")
+			rpc := &receiptRPC{pendingPolls: 1 << 30} // never found
+			client := newReceiptRPC(t, rpc)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			done := make(chan error, 1)
+			go func() {
+				_, err := WaitReceiptRaw(ctx, client, txHash, tt.opts)
+				done <- err
+			}()
+
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Error("expected a cancellation error")
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("WaitReceiptRaw did not stop promptly on cancellation")
+			}
+		})
+	}
+}

--- a/util/send.go
+++ b/util/send.go
@@ -13,7 +13,8 @@ import (
 )
 
 // SendTx is a simple wrapper to send a transaction from one Ethereum address to another.
-func SendTx(ctx context.Context, c *ethclient.Client, privateKey *ecdsa.PrivateKey, to *common.Address, amount *big.Int, data []byte, gasLimit uint64) error {
+// A nil gasPrice uses the client's suggested gas price.
+func SendTx(ctx context.Context, c *ethclient.Client, privateKey *ecdsa.PrivateKey, to *common.Address, amount, gasPrice *big.Int, data []byte, gasLimit uint64) error {
 	// Get the chaind id.
 	chainID, err := c.ChainID(ctx)
 	if err != nil {
@@ -28,11 +29,12 @@ func SendTx(ctx context.Context, c *ethclient.Client, privateKey *ecdsa.PrivateK
 		return err
 	}
 
-	// Get suggested gas price.
-	var gasPrice *big.Int
-	gasPrice, err = c.SuggestGasPrice(ctx)
-	if err != nil {
-		return err
+	// Get suggested gas price unless one was provided.
+	if gasPrice == nil {
+		gasPrice, err = c.SuggestGasPrice(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Create and sign the transaction.


### PR DESCRIPTION
Two independent changes, one commit each — the bug fixes first, so they can be split out or cherry-picked if you'd rather they land on their own.

## 1. `fix(loadtest)`: two bugs on the plain send path

Both pre-date this branch and reproduce without `--sync-txs`. I hit them while testing the feature below.

**Nil gas prices panicked the run.** `getSuggestedGasPrices` returns the cached price and tip cap from six early returns, three of which are RPC-failure paths that run *before* the cache is first written. On a first-call failure they returned `(nil, nil)`, and `configureTransactOpts` dereferences the result (`tops.GasTipCap.Cmp(...)`), so one failed `eth_feeHistory` or `eth_maxPriorityFeePerGas` killed the run with a stack trace. `suggestMaxFeePerGas` likewise returns nil when `HeaderByNumber` or `FeeHistory` fails, and that nil was being cached and handed out.

Those returns now go through a `cachedPrices` helper that substitutes zero for an unset value, and a nil from `suggestMaxFeePerGas` falls back instead of being cached. The RPC error is already logged at each site so the cause stays visible, and a zero-priced transaction is rejected by the node and recorded as a send error — the same outcome `account.go` already settles for, and better than losing the run. The helper returns *copies*: these values outlive the lock and every sending goroutine holds one, so handing out the cached pointers would make any in-place arithmetic by a future caller a silent race on shared state.

**`--rate-limit -1` hung the run permanently.** `waitForFinalBlock` built its limiter straight from `--rate-limit`, without the non-positive check the main loop applies ~1000 lines earlier. A negative `rate.Limit` has tokens that never replenish: the first nonce check took the initial token and every later one blocked on `Wait` forever, so `wg.Wait` never returned. **Any run with rate limiting disabled and more than one account hung after sending** — not a slow wait, an unbounded one. The retry loop also used a bare `time.Sleep(5s)` × 30 retries, so Ctrl+C was ignored for up to 150 seconds.

Now: no limiter when the rate limit is non-positive, the `rl != nil` guard already used at the other wait site, `time.NewTimer` + `select` on `ctx.Done()`, and a cancellation check per retry.

Verified against a fake node: the feeHistory-less case exits 0 with `Unable to get fee history` logged instead of panicking, and the `--rate-limit -1` case **exits 0.3s after SIGINT** with debug logs confirming it was inside the retry loop.

## 2. `feat(loadtest)`: `--sync-txs` for `eth_sendRawTransactionSync`

Sends via [EIP-7966](https://eips.ethereum.org/EIPS/eip-7966) `eth_sendRawTransactionSync`, which returns when the node has a receipt rather than when the transaction is accepted — so on a preconfirming chain it measures preconfirmation latency directly. Implemented as a send-path option alongside `--private-txs` rather than a mode, so it composes with every workload that broadcasts raw: `transaction`, `blob`, `contract-call`, `recall`.

**Where bor and the EIP disagree, this follows bor** ([`internal/ethapi/api.go`](https://github.com/0xPolygon/bor/blob/master/internal/ethapi/api.go)):

| | EIP-7966 | bor | this PR |
|---|---|---|---|
| timeout encoding | integer | `*hexutil.Uint64` → hex string only | hex by default, `--sync-tx-timeout-int` for the integer form |
| error codes | 4, 5, 6 | only 4; refusals return `-38010/-38011/-38013/-38014/-38026` | both sets classified |
| speculative marker | none defined | `"preconfirmation": true`, null `blockHash` | marker is authoritative; block-fields fallback otherwise |
| default wait | 2s recommended | 20s, clamps above `--rpc.txsync.maxtimeout` | documented, parameter omitted when unset |

The encoding one matters most: my first cut sent an integer per the spec text and **would have failed against every bor node**. Proven both ways against a bor-accurate fake — hex gives 30 receipts, integer gives 8/8 `cannot unmarshal non-string into Go value of type hexutil.Uint64`.

A `SyncTracker` on `mode.Dependencies` logs a summary at run end: receipts split speculative/canonical, reverted, no_status, timeouts, queued, nonce_gaps, rejected, and call latency percentiles.

**This changes what the latency numbers mean** — recorded request duration becomes time-to-receipt rather than time-to-accept, so `--concurrency` is the number of transactions in flight. Called out in the usage docs.

## Testing

24 new tests across `loadtest/mode`, `loadtest/config` and `loadtest`; `-race` clean, full suite green, `go vet` and `golangci-lint` clean, `make gen-doc` run.

End-to-end against a fake bor implementing the sync method: `submitted:50 receipts:30 speculative:20 canonical:10 timeouts:10 nonce_gaps:10 other_errors:0`.

**Not tested against a real node.** Everything here was verified against fakes built from bor's source and its own test assertions — no run against a live bor with the preconfirmation pipeline enabled, which is the configuration the speculative path actually needs (that pipeline is still unmerged, [bor#2373](https://github.com/0xPolygon/bor/pull/2373)). Against stock bor `speculative` will read zero, because it requires both a block number and hash before answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
